### PR TITLE
fix action as `set` for usage reporting in usage based sample

### DIFF
--- a/usage-based-subscriptions/server/java/src/main/java/com/stripe/sample/ReportUsage.java
+++ b/usage-based-subscriptions/server/java/src/main/java/com/stripe/sample/ReportUsage.java
@@ -40,7 +40,7 @@ public class ReportUsage {
         UsageRecordCreateOnSubscriptionItemParams.builder()
           .setQuantity(usageQuantity)
           .setTimestamp(timestamp)
-          .setAction(UsageRecordCreateOnSubscriptionItemParams.Action.INCREMENT)
+          .setAction(UsageRecordCreateOnSubscriptionItemParams.Action.SET)
           .build();
 
         RequestOptions options = RequestOptions

--- a/usage-based-subscriptions/server/node/reportUsage.js
+++ b/usage-based-subscriptions/server/node/reportUsage.js
@@ -28,7 +28,7 @@ const timestamp = parseInt(Date.now() / 1000);
       {
         quantity: usageQuantity,
         timestamp: timestamp,
-        action: 'increment',
+        action: 'set',
       },
       {
         idempotencyKey

--- a/usage-based-subscriptions/server/php/report_usage.php
+++ b/usage-based-subscriptions/server/php/report_usage.php
@@ -23,6 +23,7 @@ $subscription_item_id = '';
 // The usage number you've been keeping track of in your database for
 // the last 24 hours.
 $usage_quantity = 100;
+$action = 'set';
 
 $date = date_create();
 $timestamp = date_timestamp_get($date);
@@ -35,6 +36,7 @@ try {
         [
             'quantity' => $usage_quantity,
             'timestamp' => $timestamp,
+            'action' -> $action
         ],
         [
             'idempotency_key' => $idempotency_key,

--- a/usage-based-subscriptions/server/python/report_usage.py
+++ b/usage-based-subscriptions/server/python/report_usage.py
@@ -40,7 +40,7 @@ def report_usage():
             subscription_item_id,
             quantity=usage_quantity,
             timestamp=timestamp,
-            action='increment',
+            action='set',
             idempotency_key=idempotency_key
         )
     except stripe.error.StripeError as e:

--- a/usage-based-subscriptions/server/ruby/report_usage.rb
+++ b/usage-based-subscriptions/server/ruby/report_usage.rb
@@ -34,7 +34,7 @@ begin
     {
       quantity: usage_quantity,
       timestamp: timestamp,
-      action: 'increment'
+      action: 'set'
     }, {
       idempotency_key: idempotency_key
     }


### PR DESCRIPTION
From the [docs](https://stripe.com/docs/api/usage_records/create?lang=php#usage_record_create-action):

> Valid values are increment (default) or set. When using `increment` the specified quantity will be added to the usage at the specified timestamp. **The `set` action will overwrite the usage quantity at that timestamp.** If the subscription has billing thresholds, increment is the only allowed value.

