### PR TITLE
invoice.payment_succeeded → invoice.paid

### DIFF
--- a/fixed-price-subscriptions/client/script.js
+++ b/fixed-price-subscriptions/client/script.js
@@ -295,8 +295,7 @@ function handleCustomerActionRequired({
           if (result.paymentIntent.status === 'succeeded') {
             // There's a risk of the customer closing the window before callback
             // execution. To handle this case, set up a webhook endpoint and
-            // listen to invoice.payment_succeeded. This webhook endpoint
-            // returns an Invoice.
+            // listen to invoice.paid. This webhook endpoint returns an Invoice.
             return {
               priceId: priceId,
               subscription: subscription,

--- a/fixed-price-subscriptions/server/dotnet/Controllers/BillingController.cs
+++ b/fixed-price-subscriptions/server/dotnet/Controllers/BillingController.cs
@@ -210,14 +210,7 @@ namespace dotnet.Controllers
                 return BadRequest();
             }
 
-            if (stripeEvent.Type == "invoice.payment_succeeded")
-            {
-                // Used to provision services after the trial has ended.
-                // The status of the invoice will show up as paid. Store the status in your
-                // database to reference when a user accesses your service to avoid hitting rate
-                // limits.
-            }
-            if (stripeEvent.Type == "invoice.payment_succeeded")
+            if (stripeEvent.Type == "invoice.paid")
             {
                 // Used to provision services after the trial has ended.
                 // The status of the invoice will show up as paid. Store the status in your

--- a/fixed-price-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/fixed-price-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
@@ -379,7 +379,7 @@ public class Server {
             }
 
             switch (event.getType()) {
-                case "invoice.payment_succeeded":
+                case "invoice.paid":
                     // Used to provision services after the trial has ended.
                     // The status of the invoice will show up as paid. Store the status in your
                     // database to reference when a user accesses your service to avoid hitting rate

--- a/fixed-price-subscriptions/server/node/server.js
+++ b/fixed-price-subscriptions/server/node/server.js
@@ -181,7 +181,7 @@ app.post(
     // https://stripe.com/docs/billing/webhooks
     // Remove comment to see the various objects sent for this sample
     switch (event.type) {
-      case 'invoice.payment_succeeded':
+      case 'invoice.paid':
         // Used to provision services after the trial has ended.
         // The status of the invoice will show up as paid. Store the status in your
         // database to reference when a user accesses your service to avoid hitting rate limits.

--- a/fixed-price-subscriptions/server/php/index.php
+++ b/fixed-price-subscriptions/server/php/index.php
@@ -208,7 +208,7 @@ $app->post('/stripe-webhook', function(Request $request, Response $response) {
     // https://stripe.com/docs/billing/webhooks
     // Remove comment to see the various objects sent for this sample
     switch ($type) {
-      case 'invoice.payment_succeeded':
+      case 'invoice.paid':
         // The status of the invoice will show up as paid. Store the status in your
         // database to reference when a user accesses your service to avoid hitting rate
         // limits.

--- a/fixed-price-subscriptions/server/python/server.py
+++ b/fixed-price-subscriptions/server/python/server.py
@@ -208,7 +208,7 @@ def webhook_received():
 
     data_object = data['object']
 
-    if event_type == 'invoice.payment_succeeded':
+    if event_type == 'invoice.paid':
         # Used to provision services after the trial has ended.
         # The status of the invoice will show up as paid. Store the status in your
         # database to reference when a user accesses your service to avoid hitting rate

--- a/fixed-price-subscriptions/server/ruby/server.rb
+++ b/fixed-price-subscriptions/server/ruby/server.rb
@@ -202,7 +202,7 @@ post '/stripe-webhook' do
   data = event['data']
   data_object = data['object']
 
-  if event_type == 'invoice.payment_succeeded'
+  if event_type == 'invoice.paid'
     # Used to provision services after the trial has ended.
     # The status of the invoice will show up as paid. Store the status in your
     # database to reference when a user accesses your service to avoid hitting rate

--- a/per-seat-subscriptions/client/script.js
+++ b/per-seat-subscriptions/client/script.js
@@ -326,8 +326,7 @@ function handleCustomerActionRequired({
           if (result.paymentIntent.status === 'succeeded') {
             // There's a risk of the customer closing the window before callback
             // execution. To handle this case, set up a webhook endpoint and
-            // listen to invoice.payment_succeeded. This webhook endpoint
-            // returns an Invoice.
+            // listen to invoice.paid. This webhook endpoint returns an Invoice.
             return {
               priceId: priceId,
               subscription: subscription,

--- a/per-seat-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/per-seat-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
@@ -520,7 +520,7 @@ public class Server {
             }
 
             switch (event.getType()) {
-                case "invoice.payment_succeeded":
+                case "invoice.paid":
                     // Used to provision services after the trial has ended.
                     // The status of the invoice will show up as paid. Store the status in your
                     // database to reference when a user accesses your service to avoid hitting rate

--- a/per-seat-subscriptions/server/node/server.js
+++ b/per-seat-subscriptions/server/node/server.js
@@ -300,7 +300,7 @@ app.post(
     // https://stripe.com/docs/billing/webhooks
     // Remove comment to see the various objects sent for this sample
     switch (event.type) {
-      case 'invoice.payment_succeeded':
+      case 'invoice.paid':
         // Used to provision services after the trial has ended.
         // The status of the invoice will show up as paid. Store the status in your
         // database to reference when a user accesses your service to avoid hitting rate limits.

--- a/per-seat-subscriptions/server/php/index.php
+++ b/per-seat-subscriptions/server/php/index.php
@@ -347,7 +347,7 @@ $app->post('/stripe-webhook', function(Request $request, Response $response) {
     // https://stripe.com/docs/billing/webhooks
     // Remove comment to see the various objects sent for this sample
     switch ($type) {
-      case 'invoice.payment_succeeded':
+      case 'invoice.paid':
         // The status of the invoice will show up as paid. Store the status in your
         // database to reference when a user accesses your service to avoid hitting rate
         // limits.

--- a/per-seat-subscriptions/server/python/server.py
+++ b/per-seat-subscriptions/server/python/server.py
@@ -295,7 +295,7 @@ def webhook_received():
 
     data_object = data['object']
 
-    if event_type == 'invoice.payment_succeeded':
+    if event_type == 'invoice.paid':
         # Used to provision services after the trial has ended.
         # The status of the invoice will show up as paid. Store the status in your
         # database to reference when a user accesses your service to avoid hitting rate

--- a/per-seat-subscriptions/server/ruby/server.rb
+++ b/per-seat-subscriptions/server/ruby/server.rb
@@ -316,7 +316,7 @@ post '/stripe-webhook' do
   data = event['data']
   data_object = data['object']
 
-  if event_type == 'invoice.payment_succeeded'
+  if event_type == 'invoice.paid'
     # Used to provision services after the trial has ended.
     # The status of the invoice will show up as paid. Store the status in your
     # database to reference when a user accesses your service to avoid hitting rate

--- a/usage-based-subscriptions/client/script.js
+++ b/usage-based-subscriptions/client/script.js
@@ -291,8 +291,7 @@ function handleCustomerActionRequired({
           if (result.paymentIntent.status === 'succeeded') {
             // There's a risk of the customer closing the window before callback
             // execution. To handle this case, set up a webhook endpoint and
-            // listen to invoice.payment_succeeded. This webhook endpoint
-            // returns an Invoice.
+            // listen to invoice.paid. This webhook endpoint returns an Invoice.
             return {
               priceId: priceId,
               subscription: subscription,

--- a/usage-based-subscriptions/server/dotnet/Controllers/BillingController.cs
+++ b/usage-based-subscriptions/server/dotnet/Controllers/BillingController.cs
@@ -211,14 +211,7 @@ namespace dotnet.Controllers
                 return BadRequest();
             }
 
-            if (stripeEvent.Type == "invoice.payment_succeeded")
-            {
-                // Used to provision services after the trial has ended.
-                // The status of the invoice will show up as paid. Store the status in your
-                // database to reference when a user accesses your service to avoid hitting rate
-                // limits.
-            }
-            if (stripeEvent.Type == "invoice.payment_succeeded")
+            if (stripeEvent.Type == "invoice.paid")
             {
                 // Used to provision services after the trial has ended.
                 // The status of the invoice will show up as paid. Store the status in your

--- a/usage-based-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/usage-based-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
@@ -380,7 +380,7 @@ public class Server {
             }
 
             switch (event.getType()) {
-                case "invoice.payment_succeeded":
+                case "invoice.paid":
                     // Used to provision services after the trial has ended.
                     // The status of the invoice will show up as paid. Store the status in your
                     // database to reference when a user accesses your service to avoid hitting rate

--- a/usage-based-subscriptions/server/node/server.js
+++ b/usage-based-subscriptions/server/node/server.js
@@ -182,7 +182,7 @@ app.post(
     // https://stripe.com/docs/billing/webhooks
     // Remove comment to see the various objects sent for this sample
     switch (event.type) {
-      case 'invoice.payment_succeeded':
+      case 'invoice.paid':
         // Used to provision services after the trial has ended.
         // The status of the invoice will show up as paid. Store the status in your
         // database to reference when a user accesses your service to avoid hitting rate limits.

--- a/usage-based-subscriptions/server/php/index.php
+++ b/usage-based-subscriptions/server/php/index.php
@@ -209,7 +209,7 @@ $app->post('/stripe-webhook', function(Request $request, Response $response) {
     // https://stripe.com/docs/billing/webhooks
     // Remove comment to see the various objects sent for this sample
     switch ($type) {
-      case 'invoice.payment_succeeded':
+      case 'invoice.paid':
         // The status of the invoice will show up as paid. Store the status in your
         // database to reference when a user accesses your service to avoid hitting rate
         // limits.

--- a/usage-based-subscriptions/server/python/server.py
+++ b/usage-based-subscriptions/server/python/server.py
@@ -214,7 +214,7 @@ def webhook_received():
 
     data_object = data['object']
 
-    if event_type == 'invoice.payment_succeeded':
+    if event_type == 'invoice.paid':
         # Used to provision services after the trial has ended.
         # The status of the invoice will show up as paid. Store the status in your
         # database to reference when a user accesses your service to avoid hitting rate

--- a/usage-based-subscriptions/server/ruby/server.rb
+++ b/usage-based-subscriptions/server/ruby/server.rb
@@ -203,7 +203,7 @@ post '/stripe-webhook' do
   data = event['data']
   data_object = data['object']
 
-  if event_type == 'invoice.payment_succeeded'
+  if event_type == 'invoice.paid'
     # Used to provision services after the trial has ended.
     # The status of the invoice will show up as paid. Store the status in your
     # database to reference when a user accesses your service to avoid hitting rate


### PR DESCRIPTION
Change sample webhook references from `invoice.payment_succeeded` to `invoice.paid`