### PR TITLE
Add support for Setup Intents for metered billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ A: We are always looking for new recipe ideas, please email dev-samples@stripe.c
 
 - [@ctrudeau-stripe](https://twitter.com/trudeaucj)
 - [@suz-stripe](https://twitter.com/noopkat)
+- [@dawn-stripe](https://twitter.com/dawnlambeth)

--- a/usage-based-subscriptions/client/script.js
+++ b/usage-based-subscriptions/client/script.js
@@ -124,7 +124,7 @@ function createPaymentMethod({ card, isPaymentRetry, invoiceId }) {
     })
     .then((result) => {
       if (result.error) {
-        displayError(error);
+        displayError(result.error);
       } else {
         if (isPaymentRetry) {
           // Update the payment method and retry invoice payment
@@ -255,6 +255,49 @@ function createCustomer() {
     });
 }
 
+function handleCardSetupRequired({
+  subscription,
+  invoice,
+  priceId,
+  paymentMethodId
+})
+{
+  let setupIntent = subscription.pending_setup_intent;
+
+  if (setupIntent && setupIntent.status === 'requires_action')
+  {
+    return stripe
+      .confirmCardSetup(setupIntent.client_secret, {
+        payment_method: paymentMethodId,
+      })
+      .then((result) => {
+        if (result.error) {
+          // start code flow to handle updating the payment details
+          // Display error message in your UI.
+          // The card was declined (i.e. insufficient funds, card has expired, etc)
+          throw result;
+        } else {
+          if (result.setupIntent.status === 'succeeded') {
+            // There's a risk of the customer closing the window before callback
+            // execution. To handle this case, set up a webhook endpoint and
+            // listen to setup_intent.succeeded.
+            return {
+              priceId: priceId,
+              subscription: subscription,
+              invoice: invoice,
+              paymentMethodId: paymentMethodId,
+            };
+          }
+        }
+      });
+  }
+  else {
+    // No customer action needed
+    return { subscription, priceId, paymentMethodId };
+  }
+}
+
+
 function handleCustomerActionRequired({
   subscription,
   invoice,
@@ -262,16 +305,14 @@ function handleCustomerActionRequired({
   paymentMethodId,
   isRetry,
 }) {
-  if (subscription && subscription.status === 'active') {
-    // subscription is active, no customer actions required.
-    return { subscription, priceId, paymentMethodId };
-  }
-
   // If it's a first payment attempt, the payment intent is on the subscription latest invoice.
   // If it's a retry, the payment intent will be on the invoice itself.
   let paymentIntent = invoice
     ? invoice.payment_intent
     : subscription.latest_invoice.payment_intent;
+
+  if (!paymentIntent)
+    return { subscription, priceId, paymentMethodId };
 
   if (
     paymentIntent.status === 'requires_action' ||
@@ -383,6 +424,7 @@ function createSubscription(customerId, paymentMethodId, priceId) {
       // Some payment methods require a customer to do additional
       // authentication with their financial institution.
       // Eg: 2FA for cards.
+      .then(handleCardSetupRequired)
       .then(handleCustomerActionRequired)
       // If attaching this card to a Customer object succeeds,
       // but attempts to charge the customer fail. You will
@@ -719,12 +761,9 @@ function changeLoadingStateprices(isLoading) {
         .classList.add('invisible');
     }
   } else {
-    let buttons = document.querySelectorAll('#button-text');
-    let loading = document.querySelectorAll('#loading');
-    for (let i = 0; i < buttons.length; i++) {
-      buttons[i].classList.remove('hidden');
-      loading[i].classList.remove('loading');
-    }
+    document.querySelector('#button-text').classList.remove('hidden');
+    document.querySelector('#loading').classList.add('hidden');
+
     document.querySelector('#submit-basic').classList.remove('invisible');
     document.querySelector('#submit-premium').classList.remove('invisible');
     if (document.getElementById('confirm-price-change-cancel')) {

--- a/usage-based-subscriptions/server/dotnet/Controllers/BillingController.cs
+++ b/usage-based-subscriptions/server/dotnet/Controllers/BillingController.cs
@@ -80,6 +80,7 @@ namespace dotnet.Controllers
                 },
             };
             subscriptionOptions.AddExpand("latest_invoice.payment_intent");
+            subscriptionOptions.AddExpand("pending_setup_intent");
             var subscriptionService = new SubscriptionService();
             try
             {

--- a/usage-based-subscriptions/server/dotnet/dotnet.csproj
+++ b/usage-based-subscriptions/server/dotnet/dotnet.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DotNetEnv" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.4" />
-    <PackageReference Include="Stripe.net" Version="37.1.0" />
+    <PackageReference Include="Stripe.net" Version="37.16.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controllers\" />

--- a/usage-based-subscriptions/server/go/server.go
+++ b/usage-based-subscriptions/server/go/server.go
@@ -168,6 +168,8 @@ func handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	subscriptionParams.AddExpand("latest_invoice.payment_intent")
+	subscriptionParams.AddExpand("pending_setup_intent")
+
 	s, err := sub.New(subscriptionParams)
 
 	if err != nil {

--- a/usage-based-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/usage-based-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java
@@ -297,7 +297,7 @@ public class Server {
               .build()
           )
           .setCustomer(customer.getId())
-          .addAllExpand(Arrays.asList("latest_invoice.payment_intent"))
+          .addAllExpand(Arrays.asList("latest_invoice.payment_intent", "pending_setup_intent"))
           .build();
 
         Subscription subscription = Subscription.create(subCreateParams);

--- a/usage-based-subscriptions/server/node/server.js
+++ b/usage-based-subscriptions/server/node/server.js
@@ -103,7 +103,7 @@ app.post('/create-subscription', async (req, res) => {
   const subscription = await stripe.subscriptions.create({
     customer: req.body.customerId,
     items: [{ price: process.env[req.body.priceId] }],
-    expand: ['latest_invoice.payment_intent'],
+    expand: ['latest_invoice.payment_intent', 'pending_setup_intent'],
   });
 
   res.send(subscription);

--- a/usage-based-subscriptions/server/php/index.php
+++ b/usage-based-subscriptions/server/php/index.php
@@ -79,7 +79,7 @@ $app->post('/create-subscription', function (
             'customer' => $body->customerId,
         ]);
     } catch (Exception $e) {
-        return $response->withJson($e->jsonBody);
+        return $response->withJson(['error' => $e->getError()]);
     }
 
     // Set the default payment method on the customer
@@ -97,7 +97,7 @@ $app->post('/create-subscription', function (
                 'price' => getenv($body->priceId),
             ],
         ],
-        'expand' => ['latest_invoice.payment_intent'],
+        'expand' => ['latest_invoice.payment_intent', 'pending_setup_intent'],
     ]);
 
     return $response->withJson($subscription);

--- a/usage-based-subscriptions/server/python/server.py
+++ b/usage-based-subscriptions/server/python/server.py
@@ -79,7 +79,7 @@ def createSubscription():
                     'price': os.getenv(data['priceId'])
                 }
             ],
-            expand=['latest_invoice.payment_intent'],
+            expand=['latest_invoice.payment_intent', 'pending_setup_intent'],
         )
         return jsonify(subscription)
     except Exception as e:

--- a/usage-based-subscriptions/server/ruby/server.rb
+++ b/usage-based-subscriptions/server/ruby/server.rb
@@ -59,7 +59,7 @@ post '/create-subscription' do
     Stripe::Subscription.create(
       customer: data['customerId'],
       items: [{ price: ENV[data['priceId']] }],
-      expand: %w[latest_invoice.payment_intent]
+      expand: %w[latest_invoice.payment_intent pending_setup_intent]
     )
 
   subscription.to_json


### PR DESCRIPTION
Metered billing charges in arrears, this means a Setup Intent will be created instead of a Payment Intent at the time of subscription create.  Added support for handling Setup Intents with a status of 'requires_action' on the client and sending the customer through the authentication flow.  

Additionally fixed some display bugs where we weren't handling card decline errors.  
Upgraded the .NET lib as the older version is missing params required for clearing usage on an invoice item. 