### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ This sample shows how to create a customer and subscribe them to a plan with
 | **⤵️ Coupon support for subscriptions**                                                                                     |                                                                                                              ✅                                                                                                               |                                                                                            ✅                                                                                            |                                                                                                             ✅                                                                                                             |                                                                               Does not support coupons                                                                                |
 
 **Demo**
-
-See a hosted version of the [sample](https://xt7b9.sse.codesandbox.io/) in test mode or [fork on codesandbox.io](https://codesandbox.io/s/github/stripe-samples/subscription-use-cases/tree/master/fixed-price-subscriptions)
-
-The hosted demo is running in test mode -- use `4242424242424242` as a test card number with any CVC + future expiration date.
+The hosted demos linked above are running in test mode -- use `4242424242424242` as a test card number with any CVC + future expiration date.
 
 Use the `4000002500003155` test card number to trigger a 3D Secure challenge flow.
 
@@ -35,7 +32,7 @@ Read more about test cards on Stripe at https://stripe.com/docs/testing.
 
 ## How to run locally
 
-This sample includes [5 server implementations](server/) in our most popular languages. Follow the steps below to run one of the servers locally.
+This sample includes 7 server implementations our most popular languages. Follow the steps below to select the integration type you want and run one of the servers locally.
 
 **1. Clone and configure the sample**
 
@@ -43,7 +40,7 @@ The Stripe CLI is the fastest way to clone and configure a sample to run locally
 
 **Using the Stripe CLI**
 
-If you haven't already installed the CLI, follow the [installation steps](https://github.com/stripe/stripe-cli#installation) in the project README. The CLI is useful for cloning samples and locally testing webhooks and Stripe integrations.
+If you haven't already installed the CLI, follow the [installation steps](https://stripe.com/docs/stripe-cli#install). The CLI is useful for cloning samples and locally testing webhooks and Stripe integrations.
 
 In your terminal shell, run the Stripe CLI command to clone the sample:
 
@@ -78,9 +75,17 @@ STRIPE_SECRET_KEY=<replace-with-your-secret-key>
 
 **2. Create Products and Plans on Stripe**
 
-This sample requires a [Price](https://stripe.com/docs/api/prices) ID to create the subscription. Products and Plans are objects on Stripe that you use to model a subscription.
+This sample requires a [Price](https://stripe.com/docs/api/prices) ID to create the subscription. Products and Prices are objects on Stripe that you use to model a subscription.
 
 You can create Products and Prices [in the Dashboard](https://dashboard.stripe.com/products) or with the [API](https://stripe.com/docs/api/prices/create). Create a Price to run this sample and add it to your `.env`.
+
+See the integration guides for examples of creating Products and Prices for different business models.
+[Fixed Price](https://stripe.com/docs/billing/subscriptions/fixed-price#create-business-model)
+
+[Usage Based Billing](https://stripe.com/docs/billing/subscriptions/metered#create-business-model)
+
+[Per Seat Billing](https://stripe.com/docs/billing/subscriptions/per-seat#create-business-model)
+
 
 **3. Follow the server instructions on how to run:**
 
@@ -123,3 +128,4 @@ A: We are always looking for new recipe ideas, please email dev-samples@stripe.c
 - [@ctrudeau-stripe](https://twitter.com/trudeaucj)
 - [@suz-stripe](https://twitter.com/noopkat)
 - [@dawn-stripe](https://twitter.com/dawnlambeth)
+- [@cjavilla-stripe](https://twitter.com/cjav_dev)

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ You can create Products and Prices [in the Dashboard](https://dashboard.stripe.c
 
 See the integration guides for examples of creating Products and Prices for different business models.
 [Fixed Price](https://stripe.com/docs/billing/subscriptions/fixed-price#create-business-model)
-
 [Usage Based Billing](https://stripe.com/docs/billing/subscriptions/metered#create-business-model)
-
 [Per Seat Billing](https://stripe.com/docs/billing/subscriptions/per-seat#create-business-model)
 
 


### PR DESCRIPTION
removed incorrect link to old server directory that is now nested within the integration type subdirFixed CLI link to direct to the docs, not the repo, and added links for creating integration type specific products and prices.  Removed some text that seemed to refer to single sample