### PR TITLE
Fix PHP static dir path

### DIFF
--- a/fixed-price-subscriptions/server/php/index.php
+++ b/fixed-price-subscriptions/server/php/index.php
@@ -34,7 +34,7 @@ $container['stripe'] = function ($c) {
 
 $app->get('/', function (Request $request, Response $response, array $args) {
     // Display checkout page
-    return $response->write(file_get_contents('../../client/index.html'));
+    return $response->write(file_get_contents(getenv('STATIC_DIR') . '/index.html'));
 });
 
 $app->get('/config', function (


### PR DESCRIPTION
r? @thorsten-stripe 

It was pointing to the repo's static path structure, but not the stripe-cli generated one; now it uses the STATIC_DIR .env variable instead.