### PR TITLE
Refactor handleSubmit() to use guard statements

### DIFF
--- a/fixed-price-subscriptions/client/react/src/PaymentForm.js
+++ b/fixed-price-subscriptions/client/react/src/PaymentForm.js
@@ -264,23 +264,26 @@ const CheckoutForm = ({ productSelected, customer }) => {
       console.log('[createPaymentMethod error]', error);
       setSubscribing(false);
       setErrorToDisplay(error && error.message);
-    } else {
-      console.log('[PaymentMethod]', paymentMethod);
-      const paymentMethodId = paymentMethod.id;
-      if (latestInvoicePaymentIntentStatus === 'requires_payment_method') {
-        // Update the payment method and retry invoice payment
-        const invoiceId = localStorage.getItem('latestInvoiceId');
-        retryInvoiceWithNewPaymentMethod({
-          paymentMethodId: paymentMethodId,
-          invoiceId: invoiceId,
-        });
-      } else {
-        // Create the subscription
-        createSubscription({
-          paymentMethodId: paymentMethodId,
-        });
-      }
+      return;
     }
+    console.log('[PaymentMethod]', paymentMethod);
+    const paymentMethodId = paymentMethod.id;
+    if (latestInvoicePaymentIntentStatus === 'requires_payment_method') {
+      // Update the payment method and retry invoice payment
+      const invoiceId = localStorage.getItem('latestInvoiceId');
+      retryInvoiceWithNewPaymentMethod({
+        paymentMethodId: paymentMethodId,
+        invoiceId: invoiceId,
+      });
+      return;
+    }
+
+    // Create the subscription
+    createSubscription({
+      paymentMethodId: paymentMethodId,
+    });
+
+    
   };
 
   if (accountInformation) {


### PR DESCRIPTION
The call to `createSubscription()` , which is the the happy-path for `handleSubmit()` was nested in a 2nd level if-else.

This change flattens the code, and brings the happy-path to a top level function indentation.
[Reference](https://refactoring.com/catalog/replaceNestedConditionalWithGuardClauses.html)

cc @ctrudeau-stripe 