### PR TITLE
Use req.header(field) to fix signature verification failure on the node example

### DIFF
--- a/fixed-price-subscriptions/server/node/server.js
+++ b/fixed-price-subscriptions/server/node/server.js
@@ -203,7 +203,7 @@ app.post(
     try {
       event = stripe.webhooks.constructEvent(
         req.body,
-        req.headers['Stripe-Signature'],
+        req.header('Stripe-Signature'),
         process.env.STRIPE_WEBHOOK_SECRET
       );
     } catch (err) {


### PR DESCRIPTION
Hello. I've found the node example for fixed-price-subscriptions does not work due to StripeSignatureVerificationError and fixed it.

According to #48, it seems `req.headers` returns different values depending on its running environment (I haven't investigated it). In my environment, `req.headers` returns headers with lower-cased keys. However, HTTP headers are case-insensitive and applications should not care letter cases. To that end, we can get header values with [`req.header(field)`](https://expressjs.com/en/api.html#req.get) instead of directly referencing the object.

## Additional information

* Stripe CLI version: 1.5.1
* Node.js version: v10.7.0
* NPM version: 6.1.0

<details>
<summary>NPM packages</summary>
<pre>
subscriptions-with-fixed-prices@1.0.0 /app/server/node
+-- @fullhuman/postcss-purgecss@2.3.0
| +-- postcss@7.0.32
| | +-- chalk@2.4.2 [90mdeduped[39m
| | +-- source-map@0.6.1
| | `-- supports-color@6.1.0
| |   `-- has-flag@3.0.0
| `-- purgecss@2.3.0
|   +-- commander@5.1.0
|   +-- glob@7.1.6
|   | +-- fs.realpath@1.0.0
|   | +-- inflight@1.0.6
|   | | +-- once@1.4.0 [90mdeduped[39m
|   | | `-- wrappy@1.0.2
|   | +-- inherits@2.0.3 [90mdeduped[39m
|   | +-- minimatch@3.0.4
|   | | `-- brace-expansion@1.1.11
|   | |   +-- balanced-match@1.0.0
|   | |   `-- concat-map@0.0.1
|   | +-- once@1.4.0
|   | | `-- wrappy@1.0.2 [90mdeduped[39m
|   | `-- path-is-absolute@1.0.1
|   +-- postcss@7.0.32 [90mdeduped[39m
|   `-- postcss-selector-parser@6.0.2 [90mdeduped[39m
+-- autoprefixer@9.8.6
| +-- browserslist@4.14.2
| | +-- caniuse-lite@1.0.30001125 [90mdeduped[39m
| | +-- electron-to-chromium@1.3.566
| | +-- escalade@3.0.2
| | `-- node-releases@1.1.61
| +-- caniuse-lite@1.0.30001125
| +-- colorette@1.2.1
| +-- normalize-range@0.1.2
| +-- num2fraction@1.2.2
| +-- postcss@7.0.32 [90mdeduped[39m
| `-- postcss-value-parser@4.1.0
+-- body-parser@1.19.0
| +-- bytes@3.1.0
| +-- content-type@1.0.4
| +-- debug@2.6.9
| | `-- ms@2.0.0
| +-- depd@1.1.2
| +-- http-errors@1.7.2
| | +-- depd@1.1.2 [90mdeduped[39m
| | +-- inherits@2.0.3
| | +-- setprototypeof@1.1.1 [90mdeduped[39m
| | +-- statuses@1.5.0 [90mdeduped[39m
| | `-- toidentifier@1.0.0
| +-- iconv-lite@0.4.24
| | `-- safer-buffer@2.1.2
| +-- on-finished@2.3.0
| | `-- ee-first@1.1.1
| +-- qs@6.7.0
| +-- raw-body@2.4.0
| | +-- bytes@3.1.0 [90mdeduped[39m
| | +-- http-errors@1.7.2 [90mdeduped[39m
| | +-- iconv-lite@0.4.24 [90mdeduped[39m
| | `-- unpipe@1.0.0
| `-- type-is@1.6.18
|   +-- media-typer@0.3.0
|   `-- mime-types@2.1.27
|     `-- mime-db@1.44.0
+-- concurrently@4.1.2
| +-- chalk@2.4.2
| | +-- ansi-styles@3.2.1
| | | `-- color-convert@1.9.3 [90mdeduped[39m
| | +-- escape-string-regexp@1.0.5
| | `-- supports-color@5.5.0
| |   `-- has-flag@3.0.0 [90mdeduped[39m
| +-- date-fns@1.30.1
| +-- lodash@4.17.20
| +-- read-pkg@4.0.1
| | +-- normalize-package-data@2.5.0
| | | +-- hosted-git-info@2.8.8
| | | +-- resolve@1.17.0 [90mdeduped[39m
| | | +-- semver@5.7.1
| | | `-- validate-npm-package-license@3.0.4
| | |   +-- spdx-correct@3.1.1
| | |   | +-- spdx-expression-parse@3.0.1 [90mdeduped[39m
| | |   | `-- spdx-license-ids@3.0.5
| | |   `-- spdx-expression-parse@3.0.1
| | |     +-- spdx-exceptions@2.3.0
| | |     `-- spdx-license-ids@3.0.5 [90mdeduped[39m
| | +-- parse-json@4.0.0
| | | +-- error-ex@1.3.2
| | | | `-- is-arrayish@0.2.1
| | | `-- json-parse-better-errors@1.0.2
| | `-- pify@3.0.0
| +-- rxjs@6.6.3
| | `-- tslib@1.13.0
| +-- spawn-command@0.0.2-1
| +-- supports-color@4.5.0
| | `-- has-flag@2.0.0
| +-- tree-kill@1.2.2
| `-- yargs@12.0.5
|   +-- cliui@4.1.0
|   | +-- string-width@2.1.1 [90mdeduped[39m
|   | +-- strip-ansi@4.0.0
|   | | `-- ansi-regex@3.0.0
|   | `-- wrap-ansi@2.1.0
|   |   +-- string-width@1.0.2
|   |   | +-- code-point-at@1.1.0
|   |   | +-- is-fullwidth-code-point@1.0.0
|   |   | | `-- number-is-nan@1.0.1
|   |   | `-- strip-ansi@3.0.1 [90mdeduped[39m
|   |   `-- strip-ansi@3.0.1
|   |     `-- ansi-regex@2.1.1
|   +-- decamelize@1.2.0
|   +-- find-up@3.0.0
|   | `-- locate-path@3.0.0
|   |   +-- p-locate@3.0.0
|   |   | `-- p-limit@2.3.0
|   |   |   `-- p-try@2.2.0
|   |   `-- path-exists@3.0.0
|   +-- get-caller-file@1.0.3
|   +-- os-locale@3.1.0
|   | +-- execa@1.0.0
|   | | +-- cross-spawn@6.0.5
|   | | | +-- nice-try@1.0.5
|   | | | +-- path-key@2.0.1
|   | | | +-- semver@5.7.1 [90mdeduped[39m
|   | | | +-- shebang-command@1.2.0
|   | | | | `-- shebang-regex@1.0.0
|   | | | `-- which@1.3.1
|   | | |   `-- isexe@2.0.0
|   | | +-- get-stream@4.1.0
|   | | | `-- pump@3.0.0
|   | | |   +-- end-of-stream@1.4.4
|   | | |   | `-- once@1.4.0 [90mdeduped[39m
|   | | |   `-- once@1.4.0 [90mdeduped[39m
|   | | +-- is-stream@1.1.0
|   | | +-- npm-run-path@2.0.2
|   | | | `-- path-key@2.0.1 [90mdeduped[39m
|   | | +-- p-finally@1.0.0
|   | | +-- signal-exit@3.0.3
|   | | `-- strip-eof@1.0.0
|   | +-- lcid@2.0.0
|   | | `-- invert-kv@2.0.0
|   | `-- mem@4.3.0
|   |   +-- map-age-cleaner@0.1.3
|   |   | `-- p-defer@1.0.0
|   |   +-- mimic-fn@2.1.0
|   |   `-- p-is-promise@2.1.0
|   +-- require-directory@2.1.1
|   +-- require-main-filename@1.0.1
|   +-- set-blocking@2.0.0
|   +-- string-width@2.1.1
|   | +-- is-fullwidth-code-point@2.0.0
|   | `-- strip-ansi@4.0.0 [90mdeduped[39m
|   +-- which-module@2.0.0
|   +-- y18n@4.0.0
|   `-- yargs-parser@11.1.1
|     +-- camelcase@5.3.1
|     `-- decamelize@1.2.0 [90mdeduped[39m
+-- dotenv@8.2.0
+-- express@4.17.1
| +-- accepts@1.3.7
| | +-- mime-types@2.1.27 [90mdeduped[39m
| | `-- negotiator@0.6.2
| +-- array-flatten@1.1.1
| +-- body-parser@1.19.0 [90mdeduped[39m
| +-- content-disposition@0.5.3
| | `-- safe-buffer@5.1.2 [90mdeduped[39m
| +-- content-type@1.0.4 [90mdeduped[39m
| +-- cookie@0.4.0
| +-- cookie-signature@1.0.6
| +-- debug@2.6.9 [90mdeduped[39m
| +-- depd@1.1.2 [90mdeduped[39m
| +-- encodeurl@1.0.2
| +-- escape-html@1.0.3
| +-- etag@1.8.1
| +-- finalhandler@1.1.2
| | +-- debug@2.6.9 [90mdeduped[39m
| | +-- encodeurl@1.0.2 [90mdeduped[39m
| | +-- escape-html@1.0.3 [90mdeduped[39m
| | +-- on-finished@2.3.0 [90mdeduped[39m
| | +-- parseurl@1.3.3 [90mdeduped[39m
| | +-- statuses@1.5.0 [90mdeduped[39m
| | `-- unpipe@1.0.0 [90mdeduped[39m
| +-- fresh@0.5.2
| +-- merge-descriptors@1.0.1
| +-- methods@1.1.2
| +-- on-finished@2.3.0 [90mdeduped[39m
| +-- parseurl@1.3.3
| +-- path-to-regexp@0.1.7
| +-- proxy-addr@2.0.6
| | +-- forwarded@0.1.2
| | `-- ipaddr.js@1.9.1
| +-- qs@6.7.0 [90mdeduped[39m
| +-- range-parser@1.2.1
| +-- safe-buffer@5.1.2
| +-- send@0.17.1
| | +-- debug@2.6.9 [90mdeduped[39m
| | +-- depd@1.1.2 [90mdeduped[39m
| | +-- destroy@1.0.4
| | +-- encodeurl@1.0.2 [90mdeduped[39m
| | +-- escape-html@1.0.3 [90mdeduped[39m
| | +-- etag@1.8.1 [90mdeduped[39m
| | +-- fresh@0.5.2 [90mdeduped[39m
| | +-- http-errors@1.7.2 [90mdeduped[39m
| | +-- mime@1.6.0
| | +-- ms@2.1.1
| | +-- on-finished@2.3.0 [90mdeduped[39m
| | +-- range-parser@1.2.1 [90mdeduped[39m
| | `-- statuses@1.5.0 [90mdeduped[39m
| +-- serve-static@1.14.1
| | +-- encodeurl@1.0.2 [90mdeduped[39m
| | +-- escape-html@1.0.3 [90mdeduped[39m
| | +-- parseurl@1.3.3 [90mdeduped[39m
| | `-- send@0.17.1 [90mdeduped[39m
| +-- setprototypeof@1.1.1
| +-- statuses@1.5.0
| +-- type-is@1.6.18 [90mdeduped[39m
| +-- utils-merge@1.0.1
| `-- vary@1.1.2
+-- postcss-cli@7.1.2
| +-- chalk@4.1.0
| | +-- ansi-styles@4.2.1
| | | +-- @types/color-name@1.1.1
| | | `-- color-convert@2.0.1
| | |   `-- color-name@1.1.4
| | `-- supports-color@7.2.0
| |   `-- has-flag@4.0.0
| +-- chokidar@3.4.2
| | +-- anymatch@3.1.1
| | | +-- normalize-path@3.0.0 [90mdeduped[39m
| | | `-- picomatch@2.2.2
| | +-- braces@3.0.2
| | | `-- fill-range@7.0.1
| | |   `-- to-regex-range@5.0.1
| | |     `-- is-number@7.0.0
| | +-- [40m[33mUNMET OPTIONAL DEPENDENCY[39m[49m fsevents@2.1.3
| | +-- glob-parent@5.1.1
| | | `-- is-glob@4.0.1 [90mdeduped[39m
| | +-- is-binary-path@2.1.0
| | | `-- binary-extensions@2.1.0
| | +-- is-glob@4.0.1
| | | `-- is-extglob@2.1.1
| | +-- normalize-path@3.0.0
| | `-- readdirp@3.4.0
| |   `-- picomatch@2.2.2 [90mdeduped[39m
| +-- dependency-graph@0.9.0
| +-- fs-extra@9.0.1
| | +-- at-least-node@1.0.0
| | +-- graceful-fs@4.2.4
| | +-- jsonfile@6.0.1
| | | +-- graceful-fs@4.2.4 [90mdeduped[39m
| | | `-- universalify@1.0.0 [90mdeduped[39m
| | `-- universalify@1.0.0
| +-- get-stdin@8.0.0
| +-- globby@11.0.1
| | +-- array-union@2.1.0
| | +-- dir-glob@3.0.1
| | | `-- path-type@4.0.0
| | +-- fast-glob@3.2.4
| | | +-- @nodelib/fs.stat@2.0.3
| | | +-- @nodelib/fs.walk@1.2.4
| | | | +-- @nodelib/fs.scandir@2.1.3
| | | | | +-- @nodelib/fs.stat@2.0.3 [90mdeduped[39m
| | | | | `-- run-parallel@1.1.9
| | | | `-- fastq@1.8.0
| | | |   `-- reusify@1.0.4
| | | +-- glob-parent@5.1.1 [90mdeduped[39m
| | | +-- merge2@1.4.1 [90mdeduped[39m
| | | +-- micromatch@4.0.2
| | | | +-- braces@3.0.2 [90mdeduped[39m
| | | | `-- picomatch@2.2.2 [90mdeduped[39m
| | | `-- picomatch@2.2.2 [90mdeduped[39m
| | +-- ignore@5.1.8
| | +-- merge2@1.4.1
| | `-- slash@3.0.0
| +-- postcss@7.0.32 [90mdeduped[39m
| +-- postcss-load-config@2.1.0
| | +-- cosmiconfig@5.2.1
| | | +-- import-fresh@2.0.0
| | | | +-- caller-path@2.0.0
| | | | | `-- caller-callsite@2.0.0
| | | | |   `-- callsites@2.0.0
| | | | `-- resolve-from@3.0.0
| | | +-- is-directory@0.3.1
| | | +-- js-yaml@3.14.0
| | | | +-- argparse@1.0.10
| | | | | `-- sprintf-js@1.0.3
| | | | `-- esprima@4.0.1
| | | `-- parse-json@4.0.0 [90mdeduped[39m
| | `-- import-cwd@2.1.0
| |   `-- import-from@2.1.0
| |     `-- resolve-from@3.0.0 [90mdeduped[39m
| +-- postcss-reporter@6.0.1
| | +-- chalk@2.4.2 [90mdeduped[39m
| | +-- lodash@4.17.20 [90mdeduped[39m
| | +-- log-symbols@2.2.0
| | | `-- chalk@2.4.2 [90mdeduped[39m
| | `-- postcss@7.0.32 [90mdeduped[39m
| +-- pretty-hrtime@1.0.3
| +-- read-cache@1.0.0
| | `-- pify@2.3.0
| `-- yargs@15.4.1
|   +-- cliui@6.0.0
|   | +-- string-width@4.2.0 [90mdeduped[39m
|   | +-- strip-ansi@6.0.0
|   | | `-- ansi-regex@5.0.0
|   | `-- wrap-ansi@6.2.0
|   |   +-- ansi-styles@4.2.1 [90mdeduped[39m
|   |   +-- string-width@4.2.0 [90mdeduped[39m
|   |   `-- strip-ansi@6.0.0 [90mdeduped[39m
|   +-- decamelize@1.2.0 [90mdeduped[39m
|   +-- find-up@4.1.0
|   | +-- locate-path@5.0.0
|   | | `-- p-locate@4.1.0
|   | |   `-- p-limit@2.3.0 [90mdeduped[39m
|   | `-- path-exists@4.0.0
|   +-- get-caller-file@2.0.5
|   +-- require-directory@2.1.1 [90mdeduped[39m
|   +-- require-main-filename@2.0.0
|   +-- set-blocking@2.0.0 [90mdeduped[39m
|   +-- string-width@4.2.0
|   | +-- emoji-regex@8.0.0
|   | +-- is-fullwidth-code-point@3.0.0
|   | `-- strip-ansi@6.0.0 [90mdeduped[39m
|   +-- which-module@2.0.0 [90mdeduped[39m
|   +-- y18n@4.0.0 [90mdeduped[39m
|   `-- yargs-parser@18.1.3
|     +-- camelcase@5.3.1 [90mdeduped[39m
|     `-- decamelize@1.2.0 [90mdeduped[39m
+-- stripe@7.15.0
| `-- qs@6.7.0 [90mdeduped[39m
`-- tailwindcss@1.8.8
  +-- @fullhuman/postcss-purgecss@2.3.0 [90mdeduped[39m
  +-- autoprefixer@9.8.6 [90mdeduped[39m
  +-- browserslist@4.14.2 [90mdeduped[39m
  +-- bytes@3.1.0 [90mdeduped[39m
  +-- chalk@4.1.0
  | +-- ansi-styles@4.2.1
  | | +-- @types/color-name@1.1.1 [90mdeduped[39m
  | | `-- color-convert@2.0.1
  | |   `-- color-name@1.1.4
  | `-- supports-color@7.2.0
  |   `-- has-flag@4.0.0
  +-- color@3.1.2
  | +-- color-convert@1.9.3
  | | `-- color-name@1.1.3
  | `-- color-string@1.5.3
  |   +-- color-name@1.1.3 [90mdeduped[39m
  |   `-- simple-swizzle@0.2.2
  |     `-- is-arrayish@0.3.2
  +-- detective@5.2.0
  | +-- acorn-node@1.8.2
  | | +-- acorn@7.4.0
  | | +-- acorn-walk@7.2.0
  | | `-- xtend@4.0.2
  | +-- defined@1.0.0
  | `-- minimist@1.2.5
  +-- fs-extra@8.1.0
  | +-- graceful-fs@4.2.4 [90mdeduped[39m
  | +-- jsonfile@4.0.0
  | | `-- graceful-fs@4.2.4 [90mdeduped[39m
  | `-- universalify@0.1.2
  +-- html-tags@3.1.0
  +-- lodash@4.17.20 [90mdeduped[39m
  +-- node-emoji@1.10.0
  | `-- lodash.toarray@4.4.0
  +-- normalize.css@8.0.1
  +-- object-hash@2.0.3
  +-- postcss@7.0.32 [90mdeduped[39m
  +-- postcss-functions@3.0.0
  | +-- glob@7.1.6 [90mdeduped[39m
  | +-- object-assign@4.1.1
  | +-- postcss@6.0.23
  | | +-- chalk@2.4.2 [90mdeduped[39m
  | | +-- source-map@0.6.1 [90mdeduped[39m
  | | `-- supports-color@5.5.0
  | |   `-- has-flag@3.0.0 [90mdeduped[39m
  | `-- postcss-value-parser@3.3.1
  +-- postcss-js@2.0.3
  | +-- camelcase-css@2.0.1
  | `-- postcss@7.0.32 [90mdeduped[39m
  +-- postcss-nested@4.2.3
  | +-- postcss@7.0.32 [90mdeduped[39m
  | `-- postcss-selector-parser@6.0.2 [90mdeduped[39m
  +-- postcss-selector-parser@6.0.2
  | +-- cssesc@3.0.0
  | +-- indexes-of@1.0.1
  | `-- uniq@1.0.1
  +-- postcss-value-parser@4.1.0 [90mdeduped[39m
  +-- pretty-hrtime@1.0.3 [90mdeduped[39m
  +-- reduce-css-calc@2.1.7
  | +-- css-unit-converter@1.1.2
  | `-- postcss-value-parser@3.3.1
  `-- resolve@1.17.0
    `-- path-parse@1.0.6


</pre>
</details>