### PR TITLE
Add sinatra-contrib to load sinatra/reloader

### DIFF
--- a/per-seat-subscriptions/server/ruby/Gemfile
+++ b/per-seat-subscriptions/server/ruby/Gemfile
@@ -6,4 +6,5 @@ gem 'dotenv'
 gem 'json'
 gem 'prettier'
 gem 'sinatra'
+gem 'sinatra-contrib', group: :development
 gem 'stripe'


### PR DESCRIPTION
I got the following error when I started the app and I added the gem to fix it.

```
web_1     | server.rb:5:in `require': cannot load such file -- sinatra/reloader (LoadError)                                                                                                                          
web_1     |     from server.rb:5:in `<main>'
```