### PR TITLE
Treat the quantity as integer, not string

### DIFF
--- a/per-seat-subscriptions/client/script.js
+++ b/per-seat-subscriptions/client/script.js
@@ -161,7 +161,7 @@ function goToPaymentPage(evt) {
 
   priceId = button.dataset.plan;
 
-  quantity = document.getElementById('quantity-input-' + priceId).value;
+  quantity = parseInt(document.getElementById('quantity-input-' + priceId).value);
 
   retrieveUpcomingInvoice(customerId, null, priceId, quantity).then(
     (response) => {


### PR DESCRIPTION
I got the following error when I was trying the golang app:

    web_1     | 2020/09/13 01:59:14 json.NewDecoder.Decode: json: cannot unmarshal string into Go struct field .quantity of type int64

It was because the script.js was sending the quantity as a string to /retrieve-upcoming-invoice like as follows.

```json
{"customerId":"cus_I0mDxZPTvsuAfK","subscriptionId":null,"newPriceId":"basic","quantity":"42"}
```