### PR TITLE
Use Werkzeug 0.15.5 or newer to fix TypeError

### DIFF
--- a/fixed-price-subscriptions/server/python/requirements.txt
+++ b/fixed-price-subscriptions/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.32.1
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.4
+Werkzeug==0.15.5

--- a/fixed-price-subscriptions/server/python/requirements.txt
+++ b/fixed-price-subscriptions/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.32.1
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.5
+Werkzeug==1.0.1

--- a/per-seat-subscriptions/server/python/requirements.txt
+++ b/per-seat-subscriptions/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.48.0
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.4
+Werkzeug==0.15.5

--- a/per-seat-subscriptions/server/python/requirements.txt
+++ b/per-seat-subscriptions/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.48.0
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.5
+Werkzeug==1.0.1

--- a/usage-based-subscriptions/server/python/requirements.txt
+++ b/usage-based-subscriptions/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.48.0
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.4
+Werkzeug==0.15.5

--- a/usage-based-subscriptions/server/python/requirements.txt
+++ b/usage-based-subscriptions/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.48.0
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.5
+Werkzeug==1.0.1


### PR DESCRIPTION
When I tried Python examples with Python 3.8.5, I got the following error:

    TypeError: required field "type_ignores" missing from Module

I updated the dependency since it seems the error is related to this issue:
https://github.com/pallets/werkzeug/issues/1551