### PR TITLE
Trying to make examples run on containers easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,15 @@ target/
 .classpath
 .factorypath
 .project
+.m2
 
 # Typescript
 dist
 
 # React
 build
+
+# Docker Compose
+.config
+.local
+.bundle

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+require_relative 'docker-compose/install'
+
+task default: %i[docker-compose]

--- a/docker-compose/dotnet.yml
+++ b/docker-compose/dotnet.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: mcr.microsoft.com/dotnet/core/sdk
+    command: ['dotnet', 'run', '--urls', 'http://0.0.0.0:4242']
+    ports: ['4242:4242']
+    working_dir: /app/server/dotnet
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/docker-compose/go.yml
+++ b/docker-compose/go.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: golang
+    command: ['go', 'run', 'server.go']
+    ports: ['4242:4242']
+    working_dir: /app/server/go
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/docker-compose/install.rb
+++ b/docker-compose/install.rb
@@ -1,0 +1,18 @@
+examples = %w[fixed-price-subscriptions per-seat-subscriptions usage-based-subscriptions]
+languages = %w[dotnet go java node php python ruby]
+files = []
+
+examples.each do |example|
+  languages.each do |language|
+    src = "docker-compose/#{language}.yml"
+    dest = "#{example}/server/#{language}/docker-compose.yml"
+
+    file dest => src do
+      sh 'cp', src, dest
+    end
+
+    files << dest
+  end
+end
+
+task 'docker-compose': files

--- a/docker-compose/java.yml
+++ b/docker-compose/java.yml
@@ -1,0 +1,15 @@
+services:
+  web:
+    image: maven
+    command: [] # will be overridden by docker-compose.override.yml
+    ports: ['4242:4242']
+    working_dir: /app/server/java
+    volumes:
+      - ../..:/app
+      - .m2:/root/.m2
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/docker-compose/node.yml
+++ b/docker-compose/node.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: node
+    command: ['npm', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/node
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/docker-compose/php.yml
+++ b/docker-compose/php.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: composer
+    command: ['composer', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/php
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/docker-compose/python.yml
+++ b/docker-compose/python.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: python:3
+    command: ['python3', '-m', 'flask', 'run', '--port=4242', '--host=0.0.0.0']
+    ports: ['4242:4242']
+    environment:
+      - FLASK_APP=server.py
+    working_dir: /app/server/python
+    volumes:
+      - ../..:/app
+      - .local:/root/.local
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/docker-compose/ruby.yml
+++ b/docker-compose/ruby.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: ruby:2.7
+    command: ['bundle', 'exec', 'ruby', 'server.rb', '-o', '0.0.0.0']
+    ports: ['4242:4242']
+    working_dir: /app/server/ruby
+    environment:
+      - BUNDLE_PATH=/app/server/ruby/.bundle
+    volumes:
+      - ../..:/app
+      - .bundle:/usr/local/bundle
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/fixed-price-subscriptions/server/dotnet/README.md
+++ b/fixed-price-subscriptions/server/dotnet/README.md
@@ -12,3 +12,12 @@ dotnet run
 ```
 
 2. Go to `https://localhost:4242` or `http://localhost:42424` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose up
+```

--- a/fixed-price-subscriptions/server/dotnet/docker-compose.yml
+++ b/fixed-price-subscriptions/server/dotnet/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: mcr.microsoft.com/dotnet/core/sdk
+    command: ['dotnet', 'run', '--urls', 'http://0.0.0.0:4242']
+    ports: ['4242:4242']
+    working_dir: /app/server/dotnet
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/fixed-price-subscriptions/server/dotnet/dotnet.csproj
+++ b/fixed-price-subscriptions/server/dotnet/dotnet.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DotNetEnv" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.4" />
-    <PackageReference Include="Stripe.net" Version="37.1.0" />
+    <PackageReference Include="Stripe.net" Version="39.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controllers\" />

--- a/fixed-price-subscriptions/server/go/README.md
+++ b/fixed-price-subscriptions/server/go/README.md
@@ -16,3 +16,12 @@ go run server.go
 ```
 
 2. Go to `localhost:4242` to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose up
+```

--- a/fixed-price-subscriptions/server/go/docker-compose.yml
+++ b/fixed-price-subscriptions/server/go/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: golang
+    command: ['go', 'run', 'server.go']
+    ports: ['4242:4242']
+    working_dir: /app/server/go
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/fixed-price-subscriptions/server/go/server.go
+++ b/fixed-price-subscriptions/server/go/server.go
@@ -36,7 +36,7 @@ func main() {
 	http.HandleFunc("/retrieve-upcoming-invoice", handleRetrieveUpcomingInvoice)
 	http.HandleFunc("/stripe-webhook", handleWebhook)
 
-	addr := "localhost:4242"
+	addr := "0.0.0.0:4242"
 	log.Printf("Listening on %s ...", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }

--- a/fixed-price-subscriptions/server/java/README.md
+++ b/fixed-price-subscriptions/server/java/README.md
@@ -19,3 +19,13 @@ java -cp target/subscriptions-with-fixed-price-1.0.0-SNAPSHOT-jar-with-dependenc
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web mvn package
+docker-compose up
+```

--- a/fixed-price-subscriptions/server/java/docker-compose.override.yml
+++ b/fixed-price-subscriptions/server/java/docker-compose.override.yml
@@ -1,0 +1,3 @@
+services:
+  web:
+    command: ['java', '-cp', 'target/subscriptions-with-fixed-price-1.0.0-SNAPSHOT-jar-with-dependencies.jar', 'com.stripe.sample.Server']

--- a/fixed-price-subscriptions/server/java/docker-compose.yml
+++ b/fixed-price-subscriptions/server/java/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  web:
+    image: maven
+    command: [] # will be overridden by docker-compose.override.yml
+    ports: ['4242:4242']
+    working_dir: /app/server/java
+    volumes:
+      - ../..:/app
+      - .m2:/root/.m2
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/fixed-price-subscriptions/server/node/README.md
+++ b/fixed-price-subscriptions/server/node/README.md
@@ -22,3 +22,13 @@ npm start
 ```
 
 3. Go to `localhost:4242` to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web npm install
+docker-compose up
+```

--- a/fixed-price-subscriptions/server/node/docker-compose.yml
+++ b/fixed-price-subscriptions/server/node/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: node
+    command: ['npm', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/node
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/fixed-price-subscriptions/server/php/README.md
+++ b/fixed-price-subscriptions/server/php/README.md
@@ -21,3 +21,13 @@ composer start
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web install
+docker-compose up
+```

--- a/fixed-price-subscriptions/server/php/composer.json
+++ b/fixed-price-subscriptions/server/php/composer.json
@@ -9,6 +9,6 @@
     "monolog/monolog": "^1.17"
   },
   "scripts": {
-    "start": "php -S localhost:4242 index.php"
+    "start": "php -S 0.0.0.0:4242 index.php"
   }
 }

--- a/fixed-price-subscriptions/server/php/docker-compose.yml
+++ b/fixed-price-subscriptions/server/php/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: composer
+    command: ['composer', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/php
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/fixed-price-subscriptions/server/python/README.md
+++ b/fixed-price-subscriptions/server/python/README.md
@@ -46,3 +46,13 @@ python3 -m flask run --port=4242
 ```
 
 4. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web pip install -r requirements.txt --user
+docker-compose up
+```

--- a/fixed-price-subscriptions/server/python/docker-compose.yml
+++ b/fixed-price-subscriptions/server/python/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: python:3
+    command: ['python3', '-m', 'flask', 'run', '--port=4242', '--host=0.0.0.0']
+    ports: ['4242:4242']
+    environment:
+      - FLASK_APP=server.py
+    working_dir: /app/server/python
+    volumes:
+      - ../..:/app
+      - .local:/root/.local
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/fixed-price-subscriptions/server/ruby/README.md
+++ b/fixed-price-subscriptions/server/ruby/README.md
@@ -22,3 +22,13 @@ ruby server.rb
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web bundle
+docker-compose up
+```

--- a/fixed-price-subscriptions/server/ruby/docker-compose.yml
+++ b/fixed-price-subscriptions/server/ruby/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: ruby:2.7
+    command: ['bundle', 'exec', 'ruby', 'server.rb', '-o', '0.0.0.0']
+    ports: ['4242:4242']
+    working_dir: /app/server/ruby
+    environment:
+      - BUNDLE_PATH=/app/server/ruby/.bundle
+    volumes:
+      - ../..:/app
+      - .bundle:/usr/local/bundle
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/per-seat-subscriptions/server/dotnet/README.md
+++ b/per-seat-subscriptions/server/dotnet/README.md
@@ -12,3 +12,12 @@ dotnet run
 ```
 
 2. Go to `https://localhost:4242` or `http://localhost:42424` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose up
+```

--- a/per-seat-subscriptions/server/dotnet/docker-compose.yml
+++ b/per-seat-subscriptions/server/dotnet/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: mcr.microsoft.com/dotnet/core/sdk
+    command: ['dotnet', 'run', '--urls', 'http://0.0.0.0:4242']
+    ports: ['4242:4242']
+    working_dir: /app/server/dotnet
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/per-seat-subscriptions/server/go/README.md
+++ b/per-seat-subscriptions/server/go/README.md
@@ -14,3 +14,12 @@ A [Go](https://golang.org) implementation
 ```
 go run server.go
 ```
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose up
+```

--- a/per-seat-subscriptions/server/go/docker-compose.yml
+++ b/per-seat-subscriptions/server/go/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: golang
+    command: ['go', 'run', 'server.go']
+    ports: ['4242:4242']
+    working_dir: /app/server/go
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/per-seat-subscriptions/server/go/server.go
+++ b/per-seat-subscriptions/server/go/server.go
@@ -49,7 +49,7 @@ func main() {
 	http.HandleFunc("/cancel-subscription", handleCancelSubscription)
 	http.HandleFunc("/stripe-webhook", handleWebhook)
 
-	addr := "localhost:4242"
+	addr := "0.0.0.0:4242"
 	log.Printf("Listening on %s ...", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }

--- a/per-seat-subscriptions/server/java/README.md
+++ b/per-seat-subscriptions/server/java/README.md
@@ -19,3 +19,13 @@ java -cp target/subscriptions-with-per-seat-pricing-1.0.0-SNAPSHOT-jar-with-depe
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web mvn package
+docker-compose up
+```

--- a/per-seat-subscriptions/server/java/docker-compose.override.yml
+++ b/per-seat-subscriptions/server/java/docker-compose.override.yml
@@ -1,0 +1,3 @@
+services:
+  web:
+    command: ['java', '-cp', 'target/subscriptions-with-per-seat-pricing-1.0.0-SNAPSHOT-jar-with-dependencies.jar', 'com.stripe.sample.Server']

--- a/per-seat-subscriptions/server/java/docker-compose.yml
+++ b/per-seat-subscriptions/server/java/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  web:
+    image: maven
+    command: [] # will be overridden by docker-compose.override.yml
+    ports: ['4242:4242']
+    working_dir: /app/server/java
+    volumes:
+      - ../..:/app
+      - .m2:/root/.m2
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/per-seat-subscriptions/server/node/README.md
+++ b/per-seat-subscriptions/server/node/README.md
@@ -22,3 +22,13 @@ npm start
 ```
 
 3. Go to `localhost:4242` to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web npm install
+docker-compose up
+```

--- a/per-seat-subscriptions/server/node/docker-compose.yml
+++ b/per-seat-subscriptions/server/node/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: node
+    command: ['npm', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/node
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/per-seat-subscriptions/server/php/README.md
+++ b/per-seat-subscriptions/server/php/README.md
@@ -21,3 +21,13 @@ composer start
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web install
+docker-compose up
+```

--- a/per-seat-subscriptions/server/php/composer.json
+++ b/per-seat-subscriptions/server/php/composer.json
@@ -9,6 +9,6 @@
     "monolog/monolog": "^1.17"
   },
   "scripts": {
-    "start": "php -S localhost:4242 index.php"
+    "start": "php -S 0.0.0.0:4242 index.php"
   }
 }

--- a/per-seat-subscriptions/server/php/docker-compose.yml
+++ b/per-seat-subscriptions/server/php/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: composer
+    command: ['composer', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/php
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/per-seat-subscriptions/server/python/README.md
+++ b/per-seat-subscriptions/server/python/README.md
@@ -47,3 +47,13 @@ python3 -m flask run --port=4242
 ```
 
 4. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web pip install -r requirements.txt --user
+docker-compose up
+```

--- a/per-seat-subscriptions/server/python/docker-compose.yml
+++ b/per-seat-subscriptions/server/python/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: python:3
+    command: ['python3', '-m', 'flask', 'run', '--port=4242', '--host=0.0.0.0']
+    ports: ['4242:4242']
+    environment:
+      - FLASK_APP=server.py
+    working_dir: /app/server/python
+    volumes:
+      - ../..:/app
+      - .local:/root/.local
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/per-seat-subscriptions/server/ruby/README.md
+++ b/per-seat-subscriptions/server/ruby/README.md
@@ -22,3 +22,13 @@ ruby server.rb
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web bundle
+docker-compose up
+```

--- a/per-seat-subscriptions/server/ruby/docker-compose.yml
+++ b/per-seat-subscriptions/server/ruby/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: ruby:2.7
+    command: ['bundle', 'exec', 'ruby', 'server.rb', '-o', '0.0.0.0']
+    ports: ['4242:4242']
+    working_dir: /app/server/ruby
+    environment:
+      - BUNDLE_PATH=/app/server/ruby/.bundle
+    volumes:
+      - ../..:/app
+      - .bundle:/usr/local/bundle
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/usage-based-subscriptions/server/dotnet/README.md
+++ b/usage-based-subscriptions/server/dotnet/README.md
@@ -12,3 +12,12 @@ dotnet run
 ```
 
 2. Go to `https://localhost:4242` or `http://localhost:42424` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose up
+```

--- a/usage-based-subscriptions/server/dotnet/docker-compose.yml
+++ b/usage-based-subscriptions/server/dotnet/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: mcr.microsoft.com/dotnet/core/sdk
+    command: ['dotnet', 'run', '--urls', 'http://0.0.0.0:4242']
+    ports: ['4242:4242']
+    working_dir: /app/server/dotnet
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/usage-based-subscriptions/server/dotnet/dotnet.csproj
+++ b/usage-based-subscriptions/server/dotnet/dotnet.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DotNetEnv" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.4" />
-    <PackageReference Include="Stripe.net" Version="37.16.0" />
+    <PackageReference Include="Stripe.net" Version="39.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Controllers\" />

--- a/usage-based-subscriptions/server/go/README.md
+++ b/usage-based-subscriptions/server/go/README.md
@@ -16,3 +16,12 @@ go run server.go
 ```
 
 2. Go to `localhost:4242` to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose up
+```

--- a/usage-based-subscriptions/server/go/docker-compose.yml
+++ b/usage-based-subscriptions/server/go/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: golang
+    command: ['go', 'run', 'server.go']
+    ports: ['4242:4242']
+    working_dir: /app/server/go
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/usage-based-subscriptions/server/go/server.go
+++ b/usage-based-subscriptions/server/go/server.go
@@ -36,7 +36,7 @@ func main() {
 	http.HandleFunc("/retrieve-upcoming-invoice", handleRetrieveUpcomingInvoice)
 	http.HandleFunc("/stripe-webhook", handleWebhook)
 
-	addr := "localhost:4242"
+	addr := "0.0.0.0:4242"
 	log.Printf("Listening on %s ...", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
 }

--- a/usage-based-subscriptions/server/java/README.md
+++ b/usage-based-subscriptions/server/java/README.md
@@ -19,3 +19,13 @@ java -cp target/subscriptions-with-metered-usage-1.0.0-SNAPSHOT-jar-with-depende
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web mvn package
+docker-compose up
+```

--- a/usage-based-subscriptions/server/java/docker-compose.override.yml
+++ b/usage-based-subscriptions/server/java/docker-compose.override.yml
@@ -1,0 +1,3 @@
+services:
+  web:
+    command: ['java', '-cp', 'target/subscriptions-with-metered-usage-1.0.0-SNAPSHOT-jar-with-dependencies.jar', 'com.stripe.sample.Server']

--- a/usage-based-subscriptions/server/java/docker-compose.yml
+++ b/usage-based-subscriptions/server/java/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  web:
+    image: maven
+    command: [] # will be overridden by docker-compose.override.yml
+    ports: ['4242:4242']
+    working_dir: /app/server/java
+    volumes:
+      - ../..:/app
+      - .m2:/root/.m2
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/usage-based-subscriptions/server/node/README.md
+++ b/usage-based-subscriptions/server/node/README.md
@@ -22,3 +22,13 @@ npm start
 ```
 
 3. Go to `localhost:4242` to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web npm install
+docker-compose up
+```

--- a/usage-based-subscriptions/server/node/docker-compose.yml
+++ b/usage-based-subscriptions/server/node/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: node
+    command: ['npm', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/node
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/usage-based-subscriptions/server/php/README.md
+++ b/usage-based-subscriptions/server/php/README.md
@@ -21,3 +21,13 @@ composer start
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web install
+docker-compose up
+```

--- a/usage-based-subscriptions/server/php/composer.json
+++ b/usage-based-subscriptions/server/php/composer.json
@@ -10,6 +10,6 @@
     "ramsey/uuid": "^4.0"
   },
   "scripts": {
-    "start": "php -S localhost:4242 index.php"
+    "start": "php -S 0.0.0.0:4242 index.php"
   }
 }

--- a/usage-based-subscriptions/server/php/docker-compose.yml
+++ b/usage-based-subscriptions/server/php/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    image: composer
+    command: ['composer', 'start']
+    ports: ['4242:4242']
+    working_dir: /app/server/php
+    volumes:
+      - ../..:/app
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/usage-based-subscriptions/server/python/README.md
+++ b/usage-based-subscriptions/server/python/README.md
@@ -46,3 +46,13 @@ python3 -m flask run --port=4242
 ```
 
 4. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web pip install -r requirements.txt --user
+docker-compose up
+```

--- a/usage-based-subscriptions/server/python/docker-compose.yml
+++ b/usage-based-subscriptions/server/python/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: python:3
+    command: ['python3', '-m', 'flask', 'run', '--port=4242', '--host=0.0.0.0']
+    ports: ['4242:4242']
+    environment:
+      - FLASK_APP=server.py
+    working_dir: /app/server/python
+    volumes:
+      - ../..:/app
+      - .local:/root/.local
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe

--- a/usage-based-subscriptions/server/ruby/README.md
+++ b/usage-based-subscriptions/server/ruby/README.md
@@ -22,3 +22,13 @@ ruby server.rb
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo
+
+### Run with docker-compose.yml
+
+```
+docker-compose run --rm stripe login
+docker-compose run --rm stripe # Copy the webhook signing secret that start with "whsec_..." and set it as STRIPE_WEBHOOK_SECRET in the .env file
+
+docker-compose run --rm web bundle
+docker-compose up
+```

--- a/usage-based-subscriptions/server/ruby/docker-compose.yml
+++ b/usage-based-subscriptions/server/ruby/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    image: ruby:2.7
+    command: ['bundle', 'exec', 'ruby', 'server.rb', '-o', '0.0.0.0']
+    ports: ['4242:4242']
+    working_dir: /app/server/ruby
+    environment:
+      - BUNDLE_PATH=/app/server/ruby/.bundle
+    volumes:
+      - ../..:/app
+      - .bundle:/usr/local/bundle
+
+  stripe:
+    image: stripe/stripe-cli
+    command: ['listen', '--forward-to', 'http://web:4242/stripe-webhook']
+    volumes:
+      - .config/stripe:/root/.config/stripe


### PR DESCRIPTION
Hello. I have been playing with the example codes since I was curious if I could run all the examples in Docker containers. As a result, I could have confirmed that most of the examples run on containers.

I think it's great if developers could try the examples out of the box with Docker. Because it will not require them to set up the development environment to try an example. So I opened this PR. 

However, there are some concerns. It adds a certain amount of files and it might increase the maintenance cost of this repository. I'd like to discuss this to make it better if you don't mind. I'd appreciate your advice.

Maybe we can make sure that all the app container boot without errors on CI (GitHub Actions?) to keep these files healthy to a certain extent.

It's OK to close this PR since it's just a kind of side effect of my investigation out of my curiosity. But if you find it's worth to do it, I will willingly work on it.

## Maintaining the docker-compose.yml files

I found that most part of the docker-compose.yml can be shared between the examples. So I put the original YAML files under the `docker-compose/` directory. I also created Rake tasks that copy the files for each example.

In this way, we can edit the original YAML files and copy them to example apps.

```
$ $EDITOR docker-compose/ruby.yml
$ rake docker-compose
cp docker-compose/dotnet.yml fixed-price-subscriptions/server/dotnet/docker-compose.yml
cp docker-compose/go.yml fixed-price-subscriptions/server/go/docker-compose.yml
cp docker-compose/java.yml fixed-price-subscriptions/server/java/docker-compose.yml
...
```

## Apps I cannot confirm so far

There is a couple of apps I couldn't confirm due to the following errors.

###  `per-seat-subscriptions/server/dotnet/`

Failed to proceed due to incompatible API version of events (2020-08-27 vs. 2020-03-02). When I updated Stripe.net, I got another error because of the library API changes.

### `per-seat-subscriptions/server/node/`

The web server booted but I got an error `No signatures found matching the expected signature for payload.` when I registered an email address. I have no idea why this happens.

## Other concerns

* English is not my first language, so feel free to point out errors and unnatural expressions.