### PR TITLE
Fixed composer json

### DIFF
--- a/fixed-price-subscriptions/server/php/composer.json
+++ b/fixed-price-subscriptions/server/php/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "subscriptionusecases",
+  "name": "subscription-use-cases/fixed-price",
   "version": "1.0.0",
   "description": "A Stripe sample implementing cards for subscriptions with fixed prices.",
   "require": {

--- a/usage-based-subscriptions/server/php/composer.json
+++ b/usage-based-subscriptions/server/php/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "subscription-use-case/metered-usage",
+  "name": "subscription-use-cases/metered-usage",
   "version": "1.0.0",
   "description": "A Stripe sample implementing cards for subscriptions with fixed prices.",
   "require": {

--- a/usage-based-subscriptions/server/php/composer.json
+++ b/usage-based-subscriptions/server/php/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "subscriptions-with-metered-usage",
+  "name": "subscription-use-case/metered-usage",
   "version": "1.0.0",
   "description": "A Stripe sample implementing cards for subscriptions with fixed prices.",
   "require": {


### PR DESCRIPTION
Running `composer install` on a freshly downloaded copy of `fixed-price-subscriptions` gets you the error:

```
  [Composer\Json\JsonValidationException]
  "./composer.json" does not match the expected JSON schema:
   - name : Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$
```

This is because composer now requires you have a very [specific naming scheme](https://getcomposer.org/doc/04-schema.md#name) in composer.json files. This PR fixes the "name" property for fixed-price and metered-usage samples. Per-seat already had the correct naming scheme.

