### PR TITLE
Use the same name to let CI run without passing the jar file path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI for stripe-samples/subscription-use-cases
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          repository: 'stripe-samples/subscription-use-cases'
 
       - uses: actions/checkout@v2
         with:
@@ -37,9 +35,7 @@ jobs:
           sample=fixed-price-subscriptions
           for lang in $(cat .cli.json | server_langs_for_integration $sample)
           do
-            configure_docker_compose_for_integration "$sample" "$lang" ../../client/vanillajs \
-                                                     target/subscriptions-with-fixed-price-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-
+            configure_docker_compose_for_integration "$sample" "$lang" ../../client/vanillajs
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/fixed_price_server_spec.rb
           done
@@ -48,9 +44,7 @@ jobs:
           sample=per-seat-subscriptions
           for lang in $(cat .cli.json | server_langs_for_integration $sample)
           do
-            configure_docker_compose_for_integration "$sample" "$lang" ../../client \
-                                                     target/subscriptions-with-per-seat-pricing-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-
+            configure_docker_compose_for_integration "$sample" "$lang" ../../client
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/per_seat_server_spec.rb
           done
@@ -59,9 +53,7 @@ jobs:
           rm -rf ${sample}/server/dotnet/ReportUsage # causes "Program.cs(14,28): error CS0017: Program has more than one entry point defined."
           for lang in $(cat .cli.json | server_langs_for_integration $sample)
           do
-            configure_docker_compose_for_integration "$sample" "$lang" ../../client \
-                                                     target/subscriptions-with-metered-usage-1.0.0-SNAPSHOT-jar-with-dependencies.jar
-
+            configure_docker_compose_for_integration "$sample" "$lang" ../../client
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/usage_based_server_spec.rb
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI for stripe-samples/subscription-use-cases
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/fixed-price-subscriptions/server/java/README.md
+++ b/fixed-price-subscriptions/server/java/README.md
@@ -16,7 +16,7 @@ mvn package
 2. Run the application
 
 ```
-java -cp target/subscriptions-with-fixed-price-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo

--- a/fixed-price-subscriptions/server/java/pom.xml
+++ b/fixed-price-subscriptions/server/java/pom.xml
@@ -18,7 +18,7 @@
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/per-seat-subscriptions/server/java/README.md
+++ b/per-seat-subscriptions/server/java/README.md
@@ -16,7 +16,7 @@ mvn package
 2. Run the application
 
 ```
-java -cp target/subscriptions-with-per-seat-pricing-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo

--- a/per-seat-subscriptions/server/java/pom.xml
+++ b/per-seat-subscriptions/server/java/pom.xml
@@ -18,7 +18,7 @@
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
             <version>2.8.0</version>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/usage-based-subscriptions/server/java/README.md
+++ b/usage-based-subscriptions/server/java/README.md
@@ -16,7 +16,7 @@ mvn package
 2. Run the application
 
 ```
-java -cp target/subscriptions-with-metered-usage-1.0.0-SNAPSHOT-jar-with-dependencies.jar com.stripe.sample.Server
+java -cp target/sample-jar-with-dependencies.jar com.stripe.sample.Server
 ```
 
 3. Go to `localhost:4242` in your browser to see the demo

--- a/usage-based-subscriptions/server/java/pom.xml
+++ b/usage-based-subscriptions/server/java/pom.xml
@@ -42,6 +42,7 @@
         </dependency>
     </dependencies>
     <build>
+        <finalName>sample</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As described in https://github.com/stripe-samples/sample-ci/pull/2, I changed the jar file names to the same one. 