### PR TITLE
update for pep8 compliance

### DIFF
--- a/fixed-price-subscriptions/server/python/server.py
+++ b/fixed-price-subscriptions/server/python/server.py
@@ -6,7 +6,7 @@ import stripe
 import json
 import os
 
-from flask import Flask, render_template, jsonify, request, send_from_directory
+from flask import Flask, render_template, jsonify, request
 from dotenv import load_dotenv, find_dotenv
 
 # Setup Stripe python client library
@@ -80,7 +80,6 @@ def create_subscription():
     # database, and set customer_id to the Stripe Customer ID of that user.
     customer_id = request.cookies.get('customer')
 
-
     # Extract the price ID from environment variables given the name
     # of the price passed from the front end.
     #
@@ -113,7 +112,7 @@ def create_subscription():
 def cancel_subscription():
     data = json.loads(request.data)
     try:
-         # Cancel the subscription by deleting it
+        # Cancel the subscription by deleting it
         deletedSubscription = stripe.Subscription.delete(data['subscriptionId'])
         return jsonify(subscription=deletedSubscription)
     except Exception as e:
@@ -127,7 +126,7 @@ def list_subscriptions():
     customer_id = request.cookies.get('customer')
 
     try:
-         # Cancel the subscription by deleting it
+        # Cancel the subscription by deleting it
         subscriptions = stripe.Subscription.list(
             customer=customer_id,
             status='all',
@@ -136,7 +135,6 @@ def list_subscriptions():
         return jsonify(subscriptions=subscriptions)
     except Exception as e:
         return jsonify(error=str(e)), 403
-
 
 
 @app.route('/invoice-preview', methods=['GET'])
@@ -209,22 +207,22 @@ def webhook_received():
 
     if event_type == 'invoice.payment_succeeded':
         if data_object['billing_reason'] == 'subscription_create':
-          # The subscription automatically activates after successful payment
-          # Set the payment method used to pay the first invoice
-          # as the default payment method for that subscription
-          subscription_id = data_object['subscription']
-          payment_intent_id = data_object['payment_intent']
+            # The subscription automatically activates after successful payment
+            # Set the payment method used to pay the first invoice
+            # as the default payment method for that subscription
+            subscription_id = data_object['subscription']
+            payment_intent_id = data_object['payment_intent']
 
-          # Retrieve the payment intent used to pay the subscription
-          payment_intent = stripe.PaymentIntent.retrieve(payment_intent_id)
+            # Retrieve the payment intent used to pay the subscription
+            payment_intent = stripe.PaymentIntent.retrieve(payment_intent_id)
 
-          # Set the default payment method
-          stripe.Subscription.modify(
-            subscription_id,
-            default_payment_method=payment_intent.payment_method
-          )
+            # Set the default payment method
+            stripe.Subscription.modify(
+              subscription_id,
+              default_payment_method=payment_intent.payment_method
+            )
 
-          print("Default payment method set for subscription:" + payment_intent.payment_method)
+            print("Default payment method set for subscription:" + payment_intent.payment_method)
     elif event_type == 'invoice.payment_failed':
         # If the payment fails or the customer does not have a valid payment method,
         # an invoice.payment_failed event is sent, the subscription becomes past_due.

--- a/per-seat-subscriptions/server/python/server.py
+++ b/per-seat-subscriptions/server/python/server.py
@@ -10,7 +10,7 @@ import stripe
 import json
 import os
 
-from flask import Flask, render_template, jsonify, request, send_from_directory
+from flask import Flask, render_template, jsonify, request
 from dotenv import load_dotenv, find_dotenv
 
 # Setup Stripe python client library
@@ -160,7 +160,7 @@ def retrieveUpcomingInvoice():
             customer=data['customerId']
         )
 
-        if subscriptionId != None:
+        if subscriptionId is not None:
             # Retrieve the subscription
             subscription = stripe.Subscription.retrieve(subscriptionId)
             params["subscription"] = subscriptionId
@@ -197,7 +197,7 @@ def retrieveUpcomingInvoice():
         invoice = stripe.Invoice.upcoming(**params)
         response = {}
 
-        if subscriptionId != None:
+        if subscriptionId is not None:
             current_period_end = subscription.current_period_end
             immediate_total = 0
             next_invoice_sum = 0
@@ -227,7 +227,7 @@ def retrieveUpcomingInvoice():
 def cancelSubscription():
     data = json.loads(request.data)
     try:
-         # Cancel the subscription by deleting it
+        # Cancel the subscription by deleting it
         deletedSubscription = stripe.Subscription.delete(
             data['subscriptionId'])
         return jsonify(deletedSubscription)
@@ -304,8 +304,6 @@ def webhook_received():
     else:
         data = request_data['data']
         event_type = request_data['type']
-
-    data_object = data['object']
 
     if event_type == 'invoice.paid':
         # Used to provision services after the trial has ended.

--- a/usage-based-subscriptions/server/python/server.py
+++ b/usage-based-subscriptions/server/python/server.py
@@ -10,7 +10,7 @@ import stripe
 import json
 import os
 
-from flask import Flask, render_template, jsonify, request, send_from_directory
+from flask import Flask, render_template, jsonify, request
 from dotenv import load_dotenv, find_dotenv
 
 # Setup Stripe python client library
@@ -92,6 +92,7 @@ def createSubscription():
     except Exception as e:
         return jsonify(error={'message': str(e)}), 200
 
+
 @app.route('/retry-invoice', methods=['POST'])
 def retrySubscription():
     data = json.loads(request.data)
@@ -150,7 +151,7 @@ def retrieveUpcomingInvoice():
 def cancelSubscription():
     data = json.loads(request.data)
     try:
-         # Cancel the subscription by deleting it
+        # Cancel the subscription by deleting it
         deletedSubscription = stripe.Subscription.delete(
             data['subscriptionId'])
         return jsonify(deletedSubscription)
@@ -211,8 +212,6 @@ def webhook_received():
     else:
         data = request_data['data']
         event_type = request_data['type']
-
-    data_object = data['object']
 
     if event_type == 'invoice.paid':
         # Used to provision services after the trial has ended.


### PR DESCRIPTION
I left the > 80 chars wide pep8 warning as it'd drift into code changes rather than style fixes, and additionally many python projects override that setting to allow 120 chars wide.