### PR TITLE
Clarify how Prices should be created for fixed-price example

### DIFF
--- a/fixed-price-subscriptions/README.md
+++ b/fixed-price-subscriptions/README.md
@@ -79,7 +79,7 @@ REACT_APP_STRIPE_PUBLISHABLE_KEY=pk_12345
 
 This sample requires a [Price](https://stripe.com/docs/api/prices) ID to create the subscription. Products and Plans are objects on Stripe that you use to model a subscription.
 
-You can create Products and Prices [in the Dashboard](https://dashboard.stripe.com/products) or with the [API](https://stripe.com/docs/api/prices/create). Create a Price to run this sample and add it to your `.env`.
+You can create Prices to work with this sample following [the instructions](../README.md#how-to-create-prices) in the root of the project.
 
 **3. Follow the server instructions on how to run:**
 


### PR DESCRIPTION
The README for the fixed-price-subscriptions example mentions creating Prices manually and then configuring them in the .env file, but in fact the code [0]  expects to find the Prices it uses in your Stripe account based on specific `lookup_key`s, so you do need to  create the sample Prices per https://github.com/stripe-samples/subscription-use-cases#how-to-create-prices or the sample will not work as expected.

[0]  - e.g https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java#L124-L131