### PR TITLE
Fix dependency conflict

### DIFF
--- a/usage-based-subscriptions/server/python/requirements.txt
+++ b/usage-based-subscriptions/server/python/requirements.txt
@@ -7,8 +7,8 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 python-dotenv==0.10.3
-requests==2.22.0
-stripe==2.48.0
+requests==2.25.1
+stripe==2.56.0
 toml==0.9.6
 urllib3==1.26.5
 Werkzeug==1.0.1


### PR DESCRIPTION
Fixes: https://github.com/stripe-samples/subscription-use-cases/runs/2879167445

I fixed a dependency conflict for `usage-based-subscriptions/server/python` by updating `requests` and `stripe` to the same versions as fixed-price-subscriptions.

I assume the CI started failing when the pip in the `python:3.8` was updated. I couldn't reproduce this error with an older pip (20.2.4) but could with a newer one (21.1.2). 

