### PR TITLE
Add e2e tests for fixed-price-subscriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,14 @@ on:
   push:
     branches:
       - master
+env:
+  STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
+  STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
+  PREMIUM: ${{ secrets.TEST_PREMIUM_PRICE }}
+  BASIC: ${{ secrets.TEST_BASIC_PRICE }}
 
 jobs:
-  test:
+  server_test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +47,6 @@ jobs:
             docker-compose exec -T runner bundle exec rspec spec/fixed_price_server_spec.rb
           done
 
-
           sample=per-seat-subscriptions
           for lang in $(cat .cli.json | server_langs_for_integration $sample)
           do
@@ -58,12 +62,6 @@ jobs:
             docker-compose up -d && wait_web_server
             docker-compose exec -T runner bundle exec rspec spec/usage_based_server_spec.rb
           done
-        env:
-          STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}
-          PREMIUM: ${{ secrets.TEST_PREMIUM_PRICE }}
-          BASIC: ${{ secrets.TEST_BASIC_PRICE }}
-
 
       - name: Collect debug information
         if: ${{ failure() }}
@@ -71,3 +69,81 @@ jobs:
           cat docker-compose.yml
           docker-compose ps -a
           docker-compose logs web
+
+  e2e_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'stripe-samples/sample-ci'
+          path: 'sample-ci'
+
+      - name: Setup dependencies
+        run: |
+          source sample-ci/helpers.sh
+          setup_dependencies
+
+      - name: Prepare tests
+        run: |
+          echo "$(cat fixed-price-subscriptions/client/react/package.json | jq '.proxy = "http://web:4242"')" > fixed-price-subscriptions/client/react/package.json
+          ln -s react-cra sample-ci/docker/react
+
+      - name: Run tests for client/vanillajs
+        if: ${{ always() }}
+        env:
+          SERVER_URL: http://web:4242
+        run: |
+          source sample-ci/helpers.sh
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=${SERVER_URL}
+          BASIC=${BASIC}
+          PREMIUM=${PREMIUM}
+          EOF
+          configure_docker_compose_for_integration fixed-price-subscriptions node ../../client/vanillajs
+          docker-compose --profile=e2e up -d && wait_web_server
+          command="docker-compose exec -T runner bundle exec rspec spec/fixed_price_e2e_spec.rb"
+          $command \
+            || $command --only-failures \
+            || $command --only-failures --format RSpec::Github::Formatter --format progress
+
+      - name: Run tests for client/react
+        if: ${{ always() }}
+        env:
+          SERVER_URL: http://frontend:3000
+        run: |
+          source sample-ci/helpers.sh
+          install_docker_compose_settings
+          export STRIPE_WEBHOOK_SECRET=$(retrieve_webhook_secret)
+          cat <<EOF >> .env
+          DOMAIN=${SERVER_URL}
+          BASIC=${BASIC}
+          PREMIUM=${PREMIUM}
+          EOF
+          configure_docker_compose_for_integration fixed-price-subscriptions node ../../client/react
+          docker-compose --profile=frontend up -d && wait_web_server
+          command="docker-compose exec -T runner bundle exec rspec spec/fixed_price_e2e_spec.rb"
+          $command \
+            || $command --only-failures \
+            || $command --only-failures --format RSpec::Github::Formatter --format progress
+
+
+      - name: Collect debug information
+        if: ${{ failure() }}
+        run: |
+          cat docker-compose.yml
+          docker-compose ps -a
+          docker-compose --profile=frontend logs web
+
+          docker cp $(docker-compose ps -qa runner | head -1):/work/tmp .
+
+      - name: Upload capybara screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: screenshots
+          path: |
+            tmp/capybara

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ build
 
 # act
 .secrets
+
+spec/examples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,9 @@ gem 'rest-client'
 gem 'byebug'
 gem 'stripe'
 gem 'dotenv'
+
+gem 'selenium-webdriver'
+gem 'capybara'
+gem 'capybara-screenshot'
+
+gem 'rspec-github', require: false

--- a/fixed-price-subscriptions/client/react/src/Register.js
+++ b/fixed-price-subscriptions/client/react/src/Register.js
@@ -40,6 +40,7 @@ const Register = (props) => {
           Email
           <input
             type="text"
+            name="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required />

--- a/spec/capybara_support.rb
+++ b/spec/capybara_support.rb
@@ -1,0 +1,34 @@
+require 'capybara/rspec'
+require 'selenium-webdriver'
+require 'capybara-screenshot/rspec'
+
+Capybara.server_host = Socket.ip_address_list.detect(&:ipv4_private?).ip_address
+
+Capybara.register_driver :chrome do |app|
+  opts = {browser: :chrome, url: ENV.fetch('SELENIUM_URL', 'http://selenium:4444/wd/hub')}
+  Capybara::Selenium::Driver.new(app, **opts)
+end
+
+Capybara::Screenshot.register_driver(:chrome) do |driver, path|
+  driver.browser.save_screenshot(path)
+end
+
+Capybara.javascript_driver = :chrome
+Capybara.default_driver = :chrome
+Capybara.default_max_wait_time = 20
+Capybara.enable_aria_label = true
+Capybara.save_path = 'tmp/capybara'
+
+module CapybaraHelpers
+  SERVER_URL = ENV.fetch('SERVER_URL', 'http://web:4242')
+
+  def server_url(path)
+    url = URI(SERVER_URL)
+    url.path = path
+    url
+  end
+end
+
+RSpec.configure do |config|
+  config.include CapybaraHelpers
+end

--- a/spec/fixed_price_e2e_spec.rb
+++ b/spec/fixed_price_e2e_spec.rb
@@ -1,0 +1,72 @@
+require 'capybara_support'
+
+RSpec.describe 'Fixed price subscription', type: :system do
+  before do
+    visit server_url('/')
+
+    expect(page).to have_selector('body')
+    click_on 'Start Demo' if page.has_link?('Start Demo', wait: false) # for client/vanillajs
+  end
+
+  example 'happy path' do
+    fill_in :email, with: 'test@example.com'
+    click_on 'Register'
+
+    within first('.price-list > div') do
+      click_on 'Select'
+    end
+
+    fill_in :name, with: 'Jenny Rosen'
+
+    within_frame find('iframe[name*=__privateStripeFrame]') do
+      fill_in 'cardnumber', with: '4242424242424242'
+      fill_in 'exp-date', with: '12 / 33'
+      fill_in 'cvc', with: '123'
+      fill_in 'postal', with: '10000'
+    end
+
+    click_on 'Subscribe'
+
+    expect(page).to have_content 'Subscriptions'
+    expect(page).to have_content 'Status: active'
+
+    click_on 'Cancel'
+
+    expect(page).to have_content 'Cancel'
+    click_on 'Cancel'
+
+    expect(page).to have_content 'Subscriptions'
+    expect(page).to have_content 'Status: canceled'
+  end
+
+  example 'with the test card that requires SCA' do
+    fill_in :email, with: 'test@example.com'
+    click_on 'Register'
+
+    within first('.price-list > div') do
+      click_on 'Select'
+    end
+
+    fill_in :name, with: 'Jenny Rosen'
+
+    within_frame find('iframe[name*=__privateStripeFrame][src*=elements]') do
+      fill_in 'cardnumber', with: '4000002500003155'
+      fill_in 'exp-date', with: '12 / 33'
+      fill_in 'cvc', with: '123'
+      fill_in 'postal', with: '10000'
+    end
+
+    click_on 'Subscribe'
+
+    within_frame first('iframe[name*=__privateStripeFrame][src*=authorize') do
+      within_frame first('iframe') do
+        within_frame first('iframe') do
+          click_on 'Complete authentication'
+        end
+      end
+    end
+
+    expect(page).to have_content 'Subscriptions'
+    expect(page).to have_content 'Status: active'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Hello. I added e2e tests for fixed-price-subscriptions samples. This runs the same tests for `client/vanillajs` and `client/react`.