### PR TITLE
Fix infinite updates of subscriptions

### DIFF
--- a/fixed-price-subscriptions/client/react/src/Account.js
+++ b/fixed-price-subscriptions/client/react/src/Account.js
@@ -40,7 +40,7 @@ const Account = () => {
       setSubscriptions(subscriptions.data);
     }
     fetchData();
-  }, [subscriptions]);
+  }, []);
 
   if (!subscriptions) {
     return '';


### PR DESCRIPTION
Hi, I noticed a bug in React client in fixed-price-subscriptions. The `subscriptions` dependency in useEffect hook and the way it was set were causing the infinite loop of updates. Now it is set after the first render only.