### PR TITLE
The changes this CI depends on have been merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
-          ref: 'multiple-runtimes'
 
       - name: Setup dependencies
         run: |
@@ -133,7 +132,6 @@ jobs:
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
-          ref: 'multiple-runtimes'
 
       - name: Setup dependencies
         run: |


### PR DESCRIPTION
Removed `ref` as the branch (https://github.com/stripe-samples/sample-ci/pull/14) has been merged.