### PR TITLE
Cancel in-progress CI runs when new one triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ env:
   PREMIUM: ${{ secrets.TEST_PREMIUM_PRICE }}
   BASIC: ${{ secrets.TEST_BASIC_PRICE }}
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   server_test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
@cjavilla-stripe This is the same as https://github.com/stripe-samples/accept-a-payment/pull/320