### PR TITLE
Replace the handler of the clientSecret from URLSearchParams to  localStorage

### DIFF
--- a/fixed-price-subscriptions/client/vanillajs/prices.js
+++ b/fixed-price-subscriptions/client/vanillajs/prices.js
@@ -49,10 +49,9 @@ const createSubscription = (priceId) => {
   })
     .then((response) => response.json())
     .then((data) => {
-      const params = new URLSearchParams(window.location.search);
-      params.append('subscriptionId', data.subscriptionId);
-      params.append('clientSecret', data.clientSecret);
-      window.location.href = '/subscribe.html?' + params.toString();
+      window.sessionStorage.setItem('subscriptionId', data.subscriptionId);
+      window.sessionStorage.setItem('clientSecret', data.clientSecret);
+      window.location.href = '/subscribe.html';
     })
     .catch((error) => {
       console.error('Error:', error);

--- a/fixed-price-subscriptions/client/vanillajs/subscribe.js
+++ b/fixed-price-subscriptions/client/vanillajs/subscribe.js
@@ -19,10 +19,8 @@ fetch('/config')
 
 // Extract the client secret query string argument. This is
 // required to confirm the payment intent from the front-end.
-const params = new URLSearchParams(window.location.search);
-const subscriptionId = params.get('subscriptionId');
-const clientSecret = params.get('clientSecret');
-
+const subscriptionId = window.sessionStorage.getItem('subscriptionId');
+const clientSecret = window.sessionStorage.getItem('clientSecret');
 // This sample only supports a Subscription with payment
 // upfront. If you offer a trial on your subscription, then
 // instead of confirming the subscription's latest_invoice's


### PR DESCRIPTION
Ref: #179
Set the response of `/create-customer` API value into localStorage instead of URLSearchParams.