### PR TITLE
chore: remove unused customer ID value

### DIFF
--- a/fixed-price-subscriptions/client/vanillajs/prices.js
+++ b/fixed-price-subscriptions/client/vanillajs/prices.js
@@ -34,9 +34,6 @@ fetch('/config')
 
 
 const createSubscription = (priceId) => {
-  const params = new URLSearchParams(window.location.search);
-  const customerId = params.get('customerId');
-
   return fetch('/create-subscription', {
     method: 'POST',
     headers: {
@@ -44,7 +41,6 @@ const createSubscription = (priceId) => {
     },
     body: JSON.stringify({
       priceId: priceId,
-      customerId: customerId,
     }),
   })
     .then((response) => response.json())


### PR DESCRIPTION
When calling the `/create-subscription` API from the vanilla JS example, we set the customer ID into the request body.
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/client/vanillajs/prices.js#L47

But the server application does not use this props. They get it from Cookie.
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/php-slim/index.php#L99
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/node/server.js#L92
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/ruby/server.rb#L72
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/dotnet/Controllers/BillingController.cs#L70
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/go/server.go#L135
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/java/src/main/java/com/stripe/sample/Server.java#L186
https://github.com/stripe-samples/subscription-use-cases/blob/master/fixed-price-subscriptions/server/python/server.py#L81

So I think we can remove the code.

Thanks!