### PR TITLE
fixed some client.js in per-seat-subscriptions

### DIFF
--- a/per-seat-subscriptions/client/script.js
+++ b/per-seat-subscriptions/client/script.js
@@ -535,7 +535,7 @@ function retrieveUpcomingInvoice(
       customerId: customerId,
       subscriptionId: subscriptionId,
       newPriceId: newPriceId,
-      quantity: quantity,
+      quantity: +quantity,
     }),
   })
     .then((response) => {
@@ -577,7 +577,7 @@ function updateSubscription(priceId, subscriptionId, quantity) {
     body: JSON.stringify({
       subscriptionId: subscriptionId,
       newPriceId: priceId,
-      quantity: quantity,
+      quantity: +quantity,
     }),
   })
     .then((response) => {
@@ -707,7 +707,7 @@ function showSubscriptionInformation() {
       accountInfo.subscriptionId = subscriptionId;
       accountInfo.priceId = currentPrice;
       accountInfo.quantity = currentQuantity;
-      accountInfo.customerId = latestInvoice.customer;
+      accountInfo.customerId = latestInvoice.customer.id;
     });
   }
 }


### PR DESCRIPTION
- I was running in Go
  - Go cannot unmarshal request each the number field because requested as string from client.js.

```
2022/01/11 17:33:26 json.NewDecoder.Decode: json: cannot unmarshal object into Go struct field .customerId of type string
2022/01/11 17:33:39 json.NewDecoder.Decode: json: cannot unmarshal object into Go struct field .customerId of type string
2022/01/11 17:34:39 json.NewDecoder.Decode: json: cannot unmarshal object into Go struct field .customerId of type string
2022/01/11 17:40:50 json.NewDecoder.Decode: json: cannot unmarshal string into Go struct field .quantity of type int64
```

