### PR TITLE
Update images and Slim framework, error handlings for webhook endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI for stripe-samples/subscription-use-cases
 on:
   push:
     branches:
+      - fix-ci
       - master
 env:
   STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,25 +21,25 @@ jobs:
       matrix:
         runtime:
           - server_type: ruby
-            server_image: ruby:3.0
+            server_image: ruby:latest
           - server_type: ruby
-            server_image: ruby:2.6
+            server_image: ruby:2.7
           - server_type: node
-            server_image: node:14.17
+            server_image: node:latest
           - server_type: node
-            server_image: node:12.22
+            server_image: node:lts
           - server_type: python
-            server_image: python:3.9
+            server_image: python:latest
           - server_type: python
-            server_image: python:3.6
+            server_image: python:3.7
           - server_type: java
-            server_image: maven:3.8-openjdk-16
+            server_image: maven:latest
           - server_type: java
             server_image: maven:3.8-openjdk-8
           - server_type: go
-            server_image: golang:1.16
+            server_image: golang:latest
           - server_type: go
-            server_image: golang:1.15
+            server_image: golang:1.17
           - server_type: dotnet
             server_image: mcr.microsoft.com/dotnet/sdk:5.0
           - server_type: dotnet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           - server_type: dotnet
             server_image: mcr.microsoft.com/dotnet/sdk:3.1
           - server_type: php-slim
-            server_image: composer:1.10
+            server_image: composer:2.2
         target:
           - sample: per-seat-subscriptions
             tests: per_seat_server_spec.rb

--- a/fixed-price-subscriptions/server/node/server.js
+++ b/fixed-price-subscriptions/server/node/server.js
@@ -221,14 +221,19 @@ app.post(
           // Retrieve the payment intent used to pay the subscription
           const payment_intent = await stripe.paymentIntents.retrieve(payment_intent_id);
 
-          const subscription = await stripe.subscriptions.update(
-            subscription_id,
-            {
-              default_payment_method: payment_intent.payment_method,
-            },
-          );
+          try {
+            const subscription = await stripe.subscriptions.update(
+              subscription_id,
+              {
+                default_payment_method: payment_intent.payment_method,
+              },
+            );
 
-          console.log("Default payment method set for subscription:" + payment_intent.payment_method);
+            console.log("Default payment method set for subscription:" + payment_intent.payment_method);
+          } catch (err) {
+            console.log(err);
+            console.log(`⚠️  Falied to update the default payment method for subscription: ${subscription_id}`);
+          }
         };
 
         break;

--- a/fixed-price-subscriptions/server/php-slim/composer.json
+++ b/fixed-price-subscriptions/server/php-slim/composer.json
@@ -3,10 +3,13 @@
   "version": "1.0.0",
   "description": "A Stripe sample implementing cards for subscriptions with fixed prices.",
   "require": {
-    "slim/slim": "^3.12",
+    "slim/slim": "^4.10",
     "vlucas/phpdotenv": "^3.4",
     "stripe/stripe-php": "^7.68.0",
-    "monolog/monolog": "^1.17"
+    "monolog/monolog": "^1.17",
+    "slim/psr7": "^1.5",
+    "php-di/slim-bridge": "^3.2",
+    "slim/http": "^1.2"
   },
   "scripts": {
     "start": "php -S 0.0.0.0:4242 index.php"

--- a/fixed-price-subscriptions/server/php-slim/index.php
+++ b/fixed-price-subscriptions/server/php-slim/index.php
@@ -239,12 +239,18 @@ $app->post('/webhook', function (Request $request, Response $response) {
               $payment_intent_id,
               []
             );
-            $stripe->subscriptions->update(
-              $subscription_id,
-              ['default_payment_method' => $payment_intent->payment_method],
-            );
 
-            $logger->info('Default payment method set for subscription:' . $payment_intent->payment_method);
+            try {
+                $stripe->subscriptions->update(
+                    $subscription_id,
+                    ['default_payment_method' => $payment_intent->payment_method],
+                );
+
+                $logger->info('Default payment method set for subscription:' . $payment_intent->payment_method);
+            } catch (Exception $e) {
+                $logger->info($e->getMessage());
+                $logger->info('️Falied to update the default payment method for subscription: ' . $subscription_id);
+            }
           };
 
           // database to reference when a user accesses your service to avoid hitting rate

--- a/fixed-price-subscriptions/server/php-slim/index.php
+++ b/fixed-price-subscriptions/server/php-slim/index.php
@@ -244,7 +244,7 @@ $app->post('/webhook', function (Request $request, Response $response) {
               ['default_payment_method' => $payment_intent->payment_method],
             );
 
-            $logger->info('Default payment method set for subscription:' + $payment_intent->payment_method);
+            $logger->info('Default payment method set for subscription:' . $payment_intent->payment_method);
           };
 
           // database to reference when a user accesses your service to avoid hitting rate


### PR DESCRIPTION
Hi. I made a couple of changes to fix errors on CI.

* Updated the Docker images.
* Updated PHP Slim from 3 to 4 because it seems 3 does not support the latest PHP.
* Added error handlings to webhook endpoints: when an `invoice.payment_succeeded` event arrived after the subscription cancellation, the StripeInvalidRequestError would occur while updating the subscription. I guess the other implementations might have the same problem, too (I applied this only for node and php-slim implementations for now).

See also: https://www.slimframework.com/docs/v4/start/upgrade.html