### PR TITLE
Update dependabot day to thursday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,73 +10,86 @@ updates:
     directory: "/fixed-price-subscriptions/server/ruby/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "bundler"
     directory: "/usage-based-subscriptions/server/ruby/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # python dependencies
   - package-ecosystem: "pip"
     directory: "/fixed-price-subscriptions/server/python/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "pip"
     directory: "/usage-based-subscriptions/server/python/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # php dependencies
   - package-ecosystem: "composer"
     directory: "/fixed-price-subscriptions/server/php/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "composer"
     directory: "/usage-based-subscriptions/server/php/"
     schedule:
       interval: "weekly"
-
+      day: "thursday"
 
   # node dependencies
   - package-ecosystem: "npm"
     directory: "/fixed-price-subscriptions/server/node/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "npm"
     directory: "/fixed-price-subscriptions/server/node-typescript/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "npm"
     directory: "/usage-based-subscriptions/server/node/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # go dependencies
   - package-ecosystem: "gomod"
     directory: "/fixed-price-subscriptions/server/go/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "gomod"
     directory: "/usage-based-subscriptions/server/go/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # java dependencies
   - package-ecosystem: "maven"
     directory: "/fixed-price-subscriptions/server/java/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "maven"
     directory: "/usage-based-subscriptions/server/java/"
     schedule:
       interval: "weekly"
+      day: "thursday"
 
   # dotnet dependencies
   - package-ecosystem: "nuget"
     directory: "/fixed-price-subscriptions/server/dotnet/"
     schedule:
       interval: "weekly"
+      day: "thursday"
   - package-ecosystem: "nuget"
     directory: "/usage-based-subscriptions/server/dotnet/"
     schedule:
       interval: "weekly"
-
+      day: "thursday"


### PR DESCRIPTION
To make maintainability of the samples easier, I'm specifying which day Dependabot should open PRs so we can try to focus our effort on a single day.