### PR TITLE
Start adding automerge action for Stripe SDKs updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+  - package-ecosystem: "bundler"
+    directory: "/per-seat-subscriptions/server/ruby/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
 
   # python dependencies
   - package-ecosystem: "pip"
@@ -28,6 +33,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+  - package-ecosystem: "pip"
+    directory: "/per-seat-subscriptions/server/python/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
 
   # php dependencies
   - package-ecosystem: "composer"
@@ -37,6 +47,11 @@ updates:
       day: "thursday"
   - package-ecosystem: "composer"
     directory: "/usage-based-subscriptions/server/php/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+  - package-ecosystem: "composer"
+    directory: "/per-seat-subscriptions/server/php/"
     schedule:
       interval: "weekly"
       day: "thursday"
@@ -57,6 +72,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+  - package-ecosystem: "npm"
+    directory: "/per-seat-subscriptions/server/node/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
 
   # go dependencies
   - package-ecosystem: "gomod"
@@ -66,6 +86,11 @@ updates:
       day: "thursday"
   - package-ecosystem: "gomod"
     directory: "/usage-based-subscriptions/server/go/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+  - package-ecosystem: "gomod"
+    directory: "/per-seat-subscriptions/server/go/"
     schedule:
       interval: "weekly"
       day: "thursday"
@@ -81,6 +106,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+  - package-ecosystem: "maven"
+    directory: "/per-seat-subscriptions/server/java/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
 
   # dotnet dependencies
   - package-ecosystem: "nuget"
@@ -90,6 +120,11 @@ updates:
       day: "thursday"
   - package-ecosystem: "nuget"
     directory: "/usage-based-subscriptions/server/dotnet/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+  - package-ecosystem: "nuget"
+    directory: "/per-seat-subscriptions/server/dotnet/"
     schedule:
       interval: "weekly"
       day: "thursday"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs on Stripe SDKs
+        if: ${{contains(steps.metadata.outputs.dependency-names, 'com.stripe:stripe-java') && steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR is adding an action to auto-merge dependabot PRs when the packages updated are Stripe SDKs. To test this, I am starting with the Stripe Java SDK. If it works as expected, I'll open another PR to add the other SDKs.