### PR TITLE
The samples now only support .NET 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - fix-ci
-      - master
+      - main
 env:
   STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}
   STRIPE_SECRET_KEY: ${{ secrets.TEST_STRIPE_SECRET_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,7 @@ jobs:
           - server_type: go
             server_image: golang:1.17
           - server_type: dotnet
-            server_image: mcr.microsoft.com/dotnet/sdk:5.0
-          - server_type: dotnet
-            server_image: mcr.microsoft.com/dotnet/sdk:3.1
+            server_image: mcr.microsoft.com/dotnet/sdk:6.0
           - server_type: php-slim
             server_image: composer:2.2
         target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   BASIC: ${{ secrets.TEST_BASIC_PRICE }}
 
 concurrency:
-  group: ci-${{ github.head_ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Hi. I updated the `ci.yml` to reflect the version that the current .Net samples support.

A couple of tests for per-seat-subscription samples in Java are also failing. I'd be happy to fix this if these samples are still needed (related: https://github.com/stripe-samples/subscription-use-cases/pull/354).
