### PR TITLE
Prevent auto updater from making breaking changes

### DIFF
--- a/usage-based-subscriptions/server/php/composer.json
+++ b/usage-based-subscriptions/server/php/composer.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "A Stripe sample implementing cards for subscriptions with fixed prices.",
   "require": {
-    "slim/slim": "^4.9",
-    "vlucas/phpdotenv": "^5.4",
+    "slim/slim": ">=3.0 <4.0",
+    "vlucas/phpdotenv": ">=3.0 <4.0",
     "stripe/stripe-php": "^9.0.0",
     "monolog/monolog": "^2.3",
     "ramsey/uuid": "^4.0"


### PR DESCRIPTION
Version 4 of both phpdotenv and slim introduce breaking changes that break the sample php server code.  This new version requiring a min and max of version 3 fixes the php sample.  This will prevent the auto-updater bot from breaking the php server sample until the code sample is rewritten to conform to the docs for the new versions of these two dependencies.