### PR TITLE
Update actions/checkout to the latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
             runtime:
               server_type: php-slim
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'
@@ -114,9 +114,9 @@ jobs:
     env:
       SERVER_URL: ${{ matrix.implementation.server_url }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'stripe-samples/sample-ci'
           path: 'sample-ci'


### PR DESCRIPTION
Updated the [actions/checkout](https://github.com/actions/checkout) to v3 since v2 has been causing the deprecation warning like this:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.