### PR TITLE
Fix failing tests

### DIFF
--- a/fixed-price-subscriptions/server/node/server.js
+++ b/fixed-price-subscriptions/server/node/server.js
@@ -33,7 +33,7 @@ if (
 }
 
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2020-08-27',
+  apiVersion: '2022-08-01',
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/subscription-use-cases/fixed-price",
     version: "0.0.1",

--- a/fixed-price-subscriptions/server/php-slim/index.php
+++ b/fixed-price-subscriptions/server/php-slim/index.php
@@ -43,7 +43,7 @@ $container->set('stripe', function ($c) {
 
     $stripe = new \Stripe\StripeClient([
       'api_key' => getenv('STRIPE_SECRET_KEY'),
-      'stripe_version' => '2020-08-27',
+      'stripe_version' => '2022-08-01',
     ]);
 
     return $stripe;

--- a/fixed-price-subscriptions/server/python/server.py
+++ b/fixed-price-subscriptions/server/python/server.py
@@ -18,7 +18,7 @@ stripe.set_app_info(
     version='0.0.1',
     url='https://github.com/stripe-samples/subscription-use-cases/fixed-price')
 
-stripe.api_version = '2020-08-27'
+stripe.api_version = '2022-08-01'
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 
 static_dir = str(os.path.abspath(os.path.join(__file__, "..", os.getenv("STATIC_DIR"))))

--- a/fixed-price-subscriptions/server/ruby/config_helper.rb
+++ b/fixed-price-subscriptions/server/ruby/config_helper.rb
@@ -196,7 +196,7 @@ class ConfigHelper
   end
 
   def dotenv_exists?
-    return true if File.exists?("./.env")
+    return true if File.exist?("./.env")
 
     env_file_path = File.join(File.dirname(__FILE__), '.env')
     if !ENV['STRIPE_SECRET_KEY'] && !File.exist?("./.env")

--- a/fixed-price-subscriptions/server/ruby/server.rb
+++ b/fixed-price-subscriptions/server/ruby/server.rb
@@ -15,7 +15,7 @@ Stripe.set_app_info(
   version: '0.0.2',
   url: 'https://github.com/stripe-samples/subscription-use-cases/fixed-price'
 )
-Stripe.api_version = '2020-08-27'
+Stripe.api_version = '2022-08-01'
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 set :static, true

--- a/fixed-price-subscriptions/server/ruby/server.rb
+++ b/fixed-price-subscriptions/server/ruby/server.rb
@@ -119,11 +119,11 @@ post '/cancel-subscription' do
   # Be sure to only cancel subscriptions of the logged in user.
   # This naiively assumes the subscriptionId belongs to the
   # authenticated user.
-  deleted_subscription = Stripe::Subscription.delete(
+  canceled_subscription = Stripe::Subscription.cancel(
     data['subscriptionId']
   )
 
-  { subscription: deleted_subscription }.to_json
+  { subscription: canceled_subscription }.to_json
 end
 
 post '/update-subscription' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,7 +111,7 @@ SERVER_URL = ENV.fetch('SERVER_URL', 'http://localhost:4242')
 Dotenv.load
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 Stripe.max_network_retries = 2
-Stripe.api_version = "2020-08-27"
+Stripe.api_version = "2022-08-01"
 
 def server_url
   SERVER_URL

--- a/usage-based-subscriptions/server/node/server.js
+++ b/usage-based-subscriptions/server/node/server.js
@@ -46,7 +46,7 @@ if (
 }
 
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2020-08-27',
+  apiVersion: '2022-08-01',
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/subscription-use-cases/usage-based-subscriptions",
     version: "0.0.1",

--- a/usage-based-subscriptions/server/php/index.php
+++ b/usage-based-subscriptions/server/php/index.php
@@ -37,7 +37,7 @@ $container['stripe'] = function ($c) {
 
     $stripe = new \Stripe\StripeClient([
       'api_key' => getenv('STRIPE_SECRET_KEY'),
-      'stripe_version' => '2020-08-27',
+      'stripe_version' => '2022-08-01',
     ]);
 
     return $stripe;

--- a/usage-based-subscriptions/server/python/server.py
+++ b/usage-based-subscriptions/server/python/server.py
@@ -22,7 +22,7 @@ stripe.set_app_info(
     version='0.0.1',
     url='https://github.com/stripe-samples/subscription-use-cases/usage-based-subscriptions')
 
-stripe.api_version = '2020-08-27'
+stripe.api_version = '2022-08-01'
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 
 static_dir = str(os.path.abspath(os.path.join(

--- a/usage-based-subscriptions/server/ruby/server.rb
+++ b/usage-based-subscriptions/server/ruby/server.rb
@@ -13,7 +13,7 @@ Stripe.set_app_info(
   version: '0.0.1',
   url: 'https://github.com/stripe-samples/subscription-use-cases/usage-based-subscriptions'
 )
-Stripe.api_version = '2020-08-27'
+Stripe.api_version = '2022-08-01'
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 set :static, true


### PR DESCRIPTION
Hi, I made a couple of changes to fix failing tests on CI.

1. Update Stripe API versions (57661e3b928db7f16aaff6703f37982ec35d8358): Some samples implemented in static-typed languages have been failing ([example](https://github.com/stripe-samples/subscription-use-cases/actions/runs/3702480622/jobs/6272807682#step:6:102)) since the specified API version was not the expected one. I updated each version to `2022-08-01` from `2020-08-27`.
2. File.exists? had been deprecated and removed from Ruby 3.1 (3cd67197d0ee4ea5bc750df47886a2afa3cdc718): updated to File.exist?
3. Stripe::Subscription.delete has been removed on 8.0.0 (6e4a7e8dc1b438b44cf88ad53943f20189b66fdc): stripe-ruby have some API changes on 8.0.0, updated.