### PR TITLE
chore: ignore sample-ci dir for CI testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ build
 .secrets
 
 spec/examples.txt
+sample-ci/


### PR DESCRIPTION
Sometimes we accidentally add the `sample-ci` directory in our local development.
Therefore, we will add the `sample-ci` directory to our .gitignore file to intentionally ignore it in our git repository.

@hibariya How do you think this update?
If this update will break our CI workflow, please let me know.