### PR TITLE
chore: upgrade react and related library

### DIFF
--- a/fixed-price-subscriptions/client/react/package.json
+++ b/fixed-price-subscriptions/client/react/package.json
@@ -3,11 +3,11 @@
   "version": "0.2.0",
   "private": true,
   "dependencies": {
-    "@stripe/react-stripe-js": "^1.1.2",
-    "@stripe/stripe-js": "^1.6.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "react-router-dom": "^5.2.0"
+    "@stripe/react-stripe-js": "^2.5.0",
+    "@stripe/stripe-js": "^3.0.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^5.3.4"
   },
   "scripts": {
     "start": "vite",
@@ -27,9 +27,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",
-    "autoprefixer": "^9.8.0",
-    "postcss-cli": "^7.1.1",
-    "vite": "^5.0.12"
+    "autoprefixer": "^10.4.17",
+    "postcss-cli": "^11.0.0",
+    "vite": "^5.1.3"
   },
   "proxy": "http://localhost:4242"
 }


### PR DESCRIPTION
Related: #730 

We will temporarily exclude `react-router-dom` from the major update targets since it requires addressing breaking changes:

```
Uncaught SyntaxError: The requested module '/node_modules/.vite/deps/react-router-dom.js?v=341d8557' does not provide an export named 'withRouter' 
```

After this update, we will separately undertake the major update adjustments.