### PR TITLE
fix typo in server.js

### DIFF
--- a/fixed-price-subscriptions/server/node/server.js
+++ b/fixed-price-subscriptions/server/node/server.js
@@ -232,7 +232,7 @@ app.post(
             console.log("Default payment method set for subscription:" + payment_intent.payment_method);
           } catch (err) {
             console.log(err);
-            console.log(`⚠️  Falied to update the default payment method for subscription: ${subscription_id}`);
+            console.log(`⚠️  Failed to update the default payment method for subscription: ${subscription_id}`);
           }
         };
 


### PR DESCRIPTION
Fixes a typo in the node server example's console output.