### PR TITLE
Update server.js

### DIFF
--- a/usage-based-subscriptions/server/node/server.js
+++ b/usage-based-subscriptions/server/node/server.js
@@ -167,7 +167,7 @@ app.post('/retrieve-upcoming-invoice', async (req, res) => {
 
 app.post('/cancel-subscription', async (req, res) => {
   // Delete the subscription
-  const deletedSubscription = await stripe.subscriptions.del(
+  const deletedSubscription = await stripe.subscriptions.cancel(
     req.body.subscriptionId
   );
   res.send(deletedSubscription);


### PR DESCRIPTION
Fix of 
TypeError: stripe.subscriptions.del is not a function after Stripe changed the way of cancelling a subscription in v9.14.0  https://github.com/stripe/stripe-node/releases/tag/v9.14.0