### PR TITLE
CI: move to `docker compose`

### DIFF
--- a/.github/workflows/ci_e2e.yaml
+++ b/.github/workflows/ci_e2e.yaml
@@ -67,8 +67,8 @@ jobs:
           EOF
 
           configure_docker_compose_for_integration "${{ matrix.target.sample }}" node ../../client/${{ matrix.implementation.client_type }} node:lts
-          docker-compose --profile="${{ matrix.implementation.profile }}" up -d && wait_web_server
-          command="docker-compose exec -T runner bundle exec rspec spec/${{ matrix.target.tests }}"
+          docker compose --profile="${{ matrix.implementation.profile }}" up -d && wait_web_server
+          command="docker compose exec -T runner bundle exec rspec spec/${{ matrix.target.tests }}"
           $command \
             || $command --only-failures \
             || $command --only-failures --format RSpec::Github::Formatter --format progress
@@ -77,11 +77,11 @@ jobs:
         if: ${{ failure() }}
         run: |
           cat .env
-          cat docker-compose.yml
-          docker-compose ps -a
-          docker-compose --profile="${{ matrix.implementation.profile }}" logs web frontend
+          cat docker compose.yml
+          docker compose ps -a
+          docker compose --profile="${{ matrix.implementation.profile }}" logs web frontend
 
-          docker cp $(docker-compose ps -qa runner | head -1):/work/tmp .
+          docker cp $(docker compose ps -qa runner | head -1):/work/tmp .
 
       - name: Upload capybara screenshots
         if: ${{ failure() }}

--- a/.github/workflows/ci_e2e.yaml
+++ b/.github/workflows/ci_e2e.yaml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ failure() }}
         run: |
           cat .env
-          cat docker compose.yml
+          cat docker-compose.yml
           docker compose ps -a
           docker compose --profile="${{ matrix.implementation.profile }}" logs web frontend
 

--- a/.github/workflows/server_test.yaml
+++ b/.github/workflows/server_test.yaml
@@ -55,13 +55,13 @@ jobs:
           EOF
 
           configure_docker_compose_for_integration "${{ matrix.target.sample }}" "${{ inputs.server_type }}" "${{ matrix.target.client_dir }}" "${{ inputs.server_image }}"
-          docker-compose up -d && wait_web_server
-          docker-compose exec -T runner bundle exec rspec spec/${{ matrix.target.tests }}
+          docker compose up -d && wait_web_server
+          docker compose exec -T runner bundle exec rspec spec/${{ matrix.target.tests }}
 
       - name: Collect debug information
         if: ${{ failure() }}
         run: |
           cat .env
-          cat docker-compose.yml
-          docker-compose ps -a
-          docker-compose logs web
+          cat docker compose.yml
+          docker compose ps -a
+          docker compose logs web

--- a/.github/workflows/server_test.yaml
+++ b/.github/workflows/server_test.yaml
@@ -62,6 +62,6 @@ jobs:
         if: ${{ failure() }}
         run: |
           cat .env
-          cat docker compose.yml
+          cat docker-compose.yml
           docker compose ps -a
           docker compose logs web


### PR DESCRIPTION
Github deprecated `docker-compose`: https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/ 