### PR TITLE
Change CI workflow triggers to pull_request

### DIFF
--- a/.github/workflows/ci_dotnet.yaml
+++ b/.github/workflows/ci_dotnet.yaml
@@ -4,14 +4,11 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'usage-based-subscriptions/server/dotnet/**'
       - 'fixed-price-subscriptions/server/dotnet/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:

--- a/.github/workflows/ci_e2e.yaml
+++ b/.github/workflows/ci_e2e.yaml
@@ -4,16 +4,13 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'fixed-price-subscriptions/client/vanillajs/**'
       - 'fixed-price-subscriptions/client/react/**'
       - 'usage-based-subscriptions/client/**'
       - '!**.css'
       - '!**.md'
+  workflow_dispatch:
   
 env:
   STRIPE_PUBLISHABLE_KEY: ${{ secrets.TEST_STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/ci_go.yaml
+++ b/.github/workflows/ci_go.yaml
@@ -4,14 +4,11 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'usage-based-subscriptions/server/go/**'
       - 'fixed-price-subscriptions/server/go/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:

--- a/.github/workflows/ci_java.yaml
+++ b/.github/workflows/ci_java.yaml
@@ -4,14 +4,11 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'usage-based-subscriptions/server/java/**'
       - 'fixed-price-subscriptions/server/java/**'
       - '!**.md'
+  workflow_dispatch:
 
 jobs:
   server_test:

--- a/.github/workflows/ci_node.yaml
+++ b/.github/workflows/ci_node.yaml
@@ -4,14 +4,11 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'usage-based-subscriptions/server/node/**'
       - 'fixed-price-subscriptions/server/node/**'
       - '!**.md'
+  workflow_dispatch:
   
 jobs:
   server_test:

--- a/.github/workflows/ci_php.yaml
+++ b/.github/workflows/ci_php.yaml
@@ -4,14 +4,11 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'usage-based-subscriptions/server/php-slim/**'
       - 'fixed-price-subscriptions/server/php-slim/**'
       - '!**.md'
+  workflow_dispatch:
   
 jobs:
   server_test:

--- a/.github/workflows/ci_python.yaml
+++ b/.github/workflows/ci_python.yaml
@@ -4,14 +4,11 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'usage-based-subscriptions/server/python/**'
       - 'fixed-price-subscriptions/server/python/**'
       - '!**.md'
+  workflow_dispatch:
   
 jobs:
   server_test:

--- a/.github/workflows/ci_ruby.yaml
+++ b/.github/workflows/ci_ruby.yaml
@@ -4,14 +4,11 @@ on:
     branches:
       - main
       - fix-ci
-  workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
     paths:
       - 'usage-based-subscriptions/server/ruby/**'
       - 'fixed-price-subscriptions/server/ruby/**'
       - '!**.md'
+  workflow_dispatch:
   
 jobs:
   server_test:


### PR DESCRIPTION
### Summary

This PR removes the `pull_request_target` from the GitHub Action workflow triggers.

Right now, by using `pull_request_target`, the workflow executes off the targeted branch. That is, if we got a PR that's trying to merge code into `main`, then the CI tests would actually run off the existing `main` branch, which isn't what we want!

But we also can't easily use a different trigger like `pull_request`. The issue is that these CI checks are meant to run end-to-end tests, making live requests using a dedicated Stripe test account. And secrets (reasonably!) aren't available to pull requests from forked repositories.

In terms of benefit/risks tradeoffs, we decided that the preferred option is to just run these tests on pushes to the main branch. We have this today, so the only change to make here was to remove the `pull_request_target` trigger.

In the process, I also updated our `push` trigger to filter on the relevant paths to prevent unnecessary workflows from being executed.

### Rollout plan

After we merge this in, let's go have Dependabot rebase all the existing PR's / branches so everything is up-to-date.