### PR TITLE
Fixed price subscriptions fixes – subscription should cancel, payment intent plumbing

### DIFF
--- a/fixed-price-subscriptions/server/node/server.js
+++ b/fixed-price-subscriptions/server/node/server.js
@@ -215,11 +215,14 @@ app.post(
           // The subscription automatically activates after successful payment
           // Set the payment method used to pay the first invoice
           // as the default payment method for that subscription
-          const subscription_id = dataObject['subscription']
-          const payment_intent_id = dataObject['payment_intent']
+          const subscription_id = dataObject.parent.subscription_details.subscription;
+
+          const subscription = await stripe.subscriptions.retrieve(subscription_id, {
+            expand: ['latest_invoice.payment_intent']
+          });
 
           // Retrieve the payment intent used to pay the subscription
-          const payment_intent = await stripe.paymentIntents.retrieve(payment_intent_id);
+          const payment_intent = subscription.latest_invoice.payment_intent;
 
           try {
             const subscription = await stripe.subscriptions.update(


### PR DESCRIPTION
Fixes several issues:

```
Argument "intent" must be a string, but got: undefined (on API request to GET /v1/payment_intents/{intent})
```

```
stripe.subscriptions.del is not a function
```